### PR TITLE
Don't build gh-pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,9 @@ jobs:
       tags:
         only:
           - /^(.*)$/
+      branches:
+        ignore:
+          - gh-pages
 
     docker:
       - image: circleci/openjdk:11-jdk


### PR DESCRIPTION
Overview
----

This PR attempts to skip builds on the gh-pages branch. I'm a little bit confused about the relationship between master and gh-pages so I have no idea if it's going to work. :man_shrugging: 

Testing
----

- not really much to do aside from make sure circleci can parse the config happily