### PR TITLE
Add STAC catalog importer

### DIFF
--- a/api/src/main/scala/com/azavea/franklin/Server.scala
+++ b/api/src/main/scala/com/azavea/franklin/Server.scala
@@ -1,9 +1,11 @@
 package com.azavea.franklin.api
 
-import java.util.concurrent.Executors
-
+import com.azavea.franklin.crawler.StacImport
+import com.azavea.franklin.api.endpoints.HelloEndpoints
+import com.azavea.franklin.api.services.HelloService
 import com.azavea.franklin.database.DatabaseConfig
 import doobie.hikari.HikariTransactor
+import doobie.implicits._
 import doobie.util.ExecutionContexts
 import org.http4s.implicits._
 import org.http4s.server.blaze._
@@ -31,6 +33,8 @@ import org.flywaydb.core.Flyway
 
 import scala.concurrent.ExecutionContext
 
+import java.util.concurrent.Executors
+
 object Server extends IOApp {
 
   val rasterIO: ContextShift[IO] = IO.contextShift(
@@ -45,19 +49,19 @@ object Server extends IOApp {
 
   val banner =
     """
-       
+
    $$$$$$$$$
-$$$$$$$$$$$$   ________                            __        __  __           
-$$$$$$$$$$$$  /        |                          /  |      /  |/  |          
-$$            $$$$$$$$/______   ______   _______  $$ |   __ $$ |$$/  _______  
- $$$$$$$$     $$ |__  /      \ /      \ /       \ $$ |  /  |$$ |/  |/       \ 
+$$$$$$$$$$$$   ________                            __        __  __
+$$$$$$$$$$$$  /        |                          /  |      /  |/  |
+$$            $$$$$$$$/______   ______   _______  $$ |   __ $$ |$$/  _______
+ $$$$$$$$     $$ |__  /      \ /      \ /       \ $$ |  /  |$$ |/  |/       \
 $$$$$$$$      $$    |/$$$$$$  |$$$$$$  |$$$$$$$  |$$ |_/$$/ $$ |$$ |$$$$$$$  |
 $$$$$$$       $$$$$/ $$ |  $$/ /    $$ |$$ |  $$ |$$   $$<  $$ |$$ |$$ |  $$ |
 $             $$ |   $$ |     /$$$$$$$ |$$ |  $$ |$$$$$$  \ $$ |$$ |$$ |  $$ |
 $$$$$$        $$ |   $$ |     $$    $$ |$$ |  $$ |$$ | $$  |$$ |$$ |$$ |  $$ |
-$$$$$         $$/    $$/       $$$$$$$/ $$/   $$/ $$/   $$/ $$/ $$/ $$/   $$/ 
+$$$$$         $$/    $$/       $$$$$$$/ $$/   $$/ $$/   $$/ $$/ $$/ $$/   $$/
 $$$$
-         
+
 """.split("\n").toList
 
   def createServer(port: Int): Resource[IO, HTTP4sServer[IO]] =
@@ -97,6 +101,19 @@ $$$$
       server
     }
 
+  case class RunImport(catalogRoot: String)
+
+  val runImportOpts: Opts[RunImport] = Opts.subcommand("import", "Import a STAC catalog") {
+    Opts
+      .option[String]("catalogRoot", "Root of STAC catalog to import")
+      .map(RunImport(_))
+  }
+
+  def runImport(stacCatalog: String): fs2.Stream[IO, Unit] = {
+    val xa = DatabaseConfig.nonHikariTransactor[IO](DatabaseConfig.jdbcDBName)
+    new StacImport(stacCatalog).run().transact(xa)
+  }
+
   case class RunMigrations()
 
   val runMigrationsOpts: Opts[RunMigrations] =
@@ -130,17 +147,22 @@ $$$$
 
   val applicationCommand: Command[Product] =
     Command("", "Your Friendly Neighborhood OGC API - Features and STAC Web Service") {
-      runServerOpts orElse runMigrationsOpts
+      runServerOpts orElse runMigrationsOpts orElse runImportOpts
     }
 
   override def run(args: List[String]): IO[ExitCode] = {
     applicationCommand.parse(args) map {
       case RunServer(port) => createServer(port).use(_ => IO.never).as(ExitCode.Success)
       case RunMigrations() => runMigrations
+      case RunImport(catalogRoot) =>
+        runImport(catalogRoot).compile.drain map { _ =>
+          ExitCode.Success
+        }
     } match {
       case Left(e) =>
         IO {
           println(e.toString())
+        } map { _ =>
           ExitCode.Error
         }
       case Right(s) => s

--- a/api/src/main/scala/com/azavea/franklin/Server.scala
+++ b/api/src/main/scala/com/azavea/franklin/Server.scala
@@ -1,8 +1,6 @@
 package com.azavea.franklin.api
 
 import com.azavea.franklin.crawler.StacImport
-import com.azavea.franklin.api.endpoints.HelloEndpoints
-import com.azavea.franklin.api.services.HelloService
 import com.azavea.franklin.database.DatabaseConfig
 import doobie.hikari.HikariTransactor
 import doobie.implicits._
@@ -79,7 +77,7 @@ $$$$
       }
       allEndpoints      = LandingPageEndpoints.endpoints ++ CollectionItemEndpoints.endpoints ++ SearchEndpoints.endpoints
       docs              = allEndpoints.toOpenAPI("Franklin", "0.0.1")
-      docRoutes         = new SwaggerHttp4s(docs.toYaml, "open-api", "spec.yaml").routes
+      docRoutes         = new SwaggerHttp4s(docs.toYaml, "open-api", "spec.yaml").routes[IO]
       landingPageRoutes = new LandingPageService[IO].routes
       searchRoutes      = new SearchService[IO](xa).routes
       collectionRoutes = new CollectionsService[IO](xa).routes <+> new CollectionItemsService[IO](

--- a/api/src/main/scala/com/azavea/franklin/Server.scala
+++ b/api/src/main/scala/com/azavea/franklin/Server.scala
@@ -38,7 +38,7 @@ object Server extends IOApp {
   val rasterIO: ContextShift[IO] = IO.contextShift(
     ExecutionContext.fromExecutor(
       Executors.newCachedThreadPool(
-        new ThreadFactoryBuilder().setNameFormat("frankil-api-%d").build()
+        new ThreadFactoryBuilder().setNameFormat("franklin-api-%d").build()
       )
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,10 @@ lazy val commonSettings = Seq(
     "locationtech-snapshots" at "https://repo.locationtech.org/content/groups/snapshots",
     Resolver.bintrayRepo("guizmaii", "maven"),
     Resolver.bintrayRepo("colisweb", "maven"),
-    "jitpack".at("https://jitpack.io")
+    "jitpack".at("https://jitpack.io"),
+    Resolver.file("local", file(Path.userHome.absolutePath + "/.ivy2/local"))(
+      Resolver.ivyStylePatterns
+    )
   ),
   addCompilerPlugin("org.spire-math" %% "kind-projector"     % "0.9.6"),
   addCompilerPlugin("com.olegpy"     %% "better-monadic-for" % "0.2.4"),

--- a/build.sbt
+++ b/build.sbt
@@ -134,7 +134,7 @@ lazy val apiDependencies = commonDependencies ++ databaseDependencies ++ Seq(
 )
 
 lazy val api = (project in file("api"))
-  .dependsOn(datamodel, database)
+  .dependsOn(datamodel, database, crawler)
   .settings(apiSettings: _*)
   .settings({
     libraryDependencies ++= apiDependencies
@@ -151,4 +151,19 @@ lazy val docs = (project in file("api-docs"))
     mdocVariables := Map(
       "VERSION" -> version.value
     )
+  )
+
+/////////////
+// CRAWLER //
+/////////////
+
+lazy val crawlerDependencies = Seq(
+  Dependencies.circeFs2
+)
+
+lazy val crawler = project
+  .dependsOn(datamodel, database)
+  .settings(commonSettings)
+  .settings(
+    libraryDependencies ++= crawlerDependencies
   )

--- a/crawler/src/main/scala/StacImport.scala
+++ b/crawler/src/main/scala/StacImport.scala
@@ -45,12 +45,6 @@ class StacImport(val catalogRoot: String) {
       collection
     }
 
-  // mock db interaction for now
-  def insertCatalog(catalog: StacCatalog): ConnectionIO[Unit] =
-    Applicative[ConnectionIO].pure {
-      println(s"Inserting catalog ${catalog.title}")
-    }
-
   def insertCollection(
       collection: StacCollection,
       parentCollection: Option[StacCollection],
@@ -153,7 +147,6 @@ class StacImport(val catalogRoot: String) {
   def run(): fs2.Stream[ConnectionIO, Unit] =
     for {
       catalog              <- readRoot
-      _                    <- fs2.Stream.eval { insertCatalog(catalog) }
       (collection, parent) <- readChildren(catalog)
       _                    <- fs2.Stream.eval { insertCollection(collection, parent, catalog) }
       item                 <- readItems(collection)

--- a/crawler/src/main/scala/StacImport.scala
+++ b/crawler/src/main/scala/StacImport.scala
@@ -5,7 +5,7 @@ import com.azavea.franklin.database.StacItemDao
 import cats.{Applicative, MonadError}
 import doobie.ConnectionIO
 import doobie.implicits._
-import geotrellis.server.stac.{decoder => _, _}
+import geotrellis.server.stac._
 import io.circe.fs2._
 import io.circe.Json
 
@@ -62,7 +62,7 @@ class StacImport(val catalogRoot: String) {
       )
     }
 
-  private def getPrefix(absPath: String): String = absPath.split("/").dropRight(1).mkString("")
+  private def getPrefix(absPath: String): String = absPath.split("/").dropRight(1).mkString("/")
 
   private def makeAbsPath(from: String, relPath: String): String = {
     val prefix       = getPrefix(from)
@@ -70,7 +70,8 @@ class StacImport(val catalogRoot: String) {
     val relPathSplit = relPath.split("/")
     val up           = relPathSplit.filter(_ == "..").size
     // safe because String.split always returns an array with an element
-    (prefixSplit.dropRight(up) :+ relPathSplit.last).mkString("/")
+    (prefixSplit.dropRight(up) :+ (if (up > 0) relPathSplit.drop(up)
+                                   else relPathSplit.drop(1)).mkString("/")) mkString ("/")
   }
 
   def readFromS3(path: String): fs2.Stream[ConnectionIO, Json] = ???

--- a/crawler/src/main/scala/StacImport.scala
+++ b/crawler/src/main/scala/StacImport.scala
@@ -1,0 +1,152 @@
+package com.azavea.franklin.crawler
+
+import cats.{Applicative, MonadError}
+import doobie.ConnectionIO
+import doobie.implicits._
+import geotrellis.server.stac.{decoder => _, _}
+import io.circe.fs2._
+import io.circe.Json
+
+class StacImport(val catalogRoot: String) {
+
+  def addSelf(collection: StacCollection, absPath: String): StacCollection =
+    if (collection.links.filter(_.rel == Self).isEmpty) {
+      collection match {
+        case x: PublicStacCollection =>
+          x.copy(
+            links = x.links :+ StacLink(
+              absPath,
+              Self,
+              Some(`application/json`),
+              collection.title,
+              List.empty
+            )
+          )
+        case x: ProprietaryStacCollection =>
+          x.copy(
+            linksWithLicenseLink = StacLinksWithLicense.unsafeFrom(
+              x.links :+ StacLink(
+                absPath,
+                Self,
+                Some(`application/json`),
+                collection.title,
+                List.empty
+              )
+            )
+          )
+      }
+    } else {
+      collection
+    }
+
+  // mock db interaction for now
+  def insertCatalog(catalog: StacCatalog): ConnectionIO[Unit] =
+    Applicative[ConnectionIO].pure {
+      println(s"Inserting catalog ${catalog.title}")
+    }
+
+  def insertCollection(
+      collection: StacCollection,
+      parentCollection: Option[StacCollection],
+      catalog: StacCatalog
+  ): ConnectionIO[Unit] =
+    Applicative[ConnectionIO].pure {
+      println(
+        s"Inserting collection ${collection.title} with parent ${parentCollection map { _.title }} into catalog ${catalog.title}"
+      )
+    }
+
+  def insertItem(item: StacItem): ConnectionIO[Unit] =
+    Applicative[ConnectionIO].pure {
+      println(
+        s"Inserting item ${item.id}"
+      )
+    }
+
+  private def getPrefix(absPath: String): String = absPath.split("/").dropRight(1).mkString("")
+
+  private def makeAbsPath(from: String, relPath: String): String = {
+    val prefix       = getPrefix(from)
+    val prefixSplit  = prefix.split("/")
+    val relPathSplit = relPath.split("/")
+    val up           = relPathSplit.filter(_ == "..").size
+    // safe because String.split always returns an array with an element
+    (prefixSplit.dropRight(up) :+ relPathSplit.last).mkString("/")
+  }
+
+  def readFromS3(path: String): fs2.Stream[ConnectionIO, Json]        = ???
+  def readFromLocalPath(path: String): fs2.Stream[ConnectionIO, Json] = ???
+
+  def readPath(path: String): fs2.Stream[ConnectionIO, Json] =
+    if (path.startsWith("s3://")) {
+      readFromS3(path)
+    } else {
+      readFromLocalPath(path)
+    }
+
+  def readRoot: fs2.Stream[ConnectionIO, StacCatalog] = {
+    readPath(catalogRoot).through(decoder[ConnectionIO, StacCatalog])
+  }
+
+  def readCollection(
+      path: String,
+      parent: Option[StacCollection]
+  ): fs2.Stream[ConnectionIO, (StacCollection, Option[StacCollection])] =
+    readPath(path).through(decoder[ConnectionIO, StacCollection]) flatMap { collection =>
+      val children = collection.links.filter(_.rel == Child)
+      if (children.isEmpty) {
+        fs2.Stream.emit((addSelf(collection, path), None)).covary[ConnectionIO]
+      } else {
+        fs2.Stream
+          .emit((collection, parent))
+          .covary[ConnectionIO] ++ (fs2.Stream.emits(children) flatMap { child =>
+          readCollection(makeAbsPath(path, child.href), Some(collection))
+        })
+      }
+    }
+
+  def readItem(path: String): fs2.Stream[ConnectionIO, StacItem] =
+    readPath(path).through(decoder[ConnectionIO, StacItem])
+
+  def readChildren(
+      catalog: StacCatalog
+  ): fs2.Stream[ConnectionIO, (StacCollection, Option[StacCollection])] = {
+    val children = catalog.links.filter(link => link.rel == Child)
+    fs2.Stream.emits(children).covary[ConnectionIO] flatMap { child =>
+      readCollection(makeAbsPath(catalogRoot, child.href), None)
+    }
+  }
+
+  def readItems(
+      collection: StacCollection
+  ): fs2.Stream[ConnectionIO, StacItem] = {
+    val collectionAbsPath: ConnectionIO[String] = collection.links
+      .filter(link => link.rel == Self)
+      .map((link: StacLink) => link.href)
+      .headOption match {
+      case Some(p) => Applicative[ConnectionIO].pure(p)
+      case _ =>
+        MonadError[ConnectionIO, Throwable].raiseError(
+          new Exception(s"No self link on collection, unable to derive item absolute path")
+        )
+    }
+
+    val items = collection.links.filter(link => link.rel == Item)
+    for {
+      absPath <- fs2.Stream.eval { collectionAbsPath }
+      result <- fs2.Stream.emits(items).covary[ConnectionIO] flatMap { item =>
+        readItem(makeAbsPath(absPath, item.href))
+      }
+    } yield result
+  }
+
+  def run(): fs2.Stream[ConnectionIO, Unit] =
+    for {
+      catalog              <- readRoot
+      _                    <- fs2.Stream.eval { insertCatalog(catalog) }
+      (collection, parent) <- readChildren(catalog)
+      _                    <- fs2.Stream.eval { insertCollection(collection, parent, catalog) }
+      item                 <- readItems(collection)
+      _                    <- fs2.Stream.eval { insertItem(item) }
+    } yield ()
+}

--- a/crawler/src/main/scala/StacImport.scala
+++ b/crawler/src/main/scala/StacImport.scala
@@ -1,6 +1,6 @@
 package com.azavea.franklin.crawler
 
-import com.azavea.franklin.database.StacItemDao
+import com.azavea.franklin.database.{StacCollectionDao, StacItemDao}
 
 import cats.{Applicative, MonadError}
 import doobie.ConnectionIO
@@ -55,11 +55,13 @@ class StacImport(val catalogRoot: String) {
       collection: StacCollection,
       parentCollection: Option[StacCollection],
       catalog: StacCatalog
-  ): ConnectionIO[Unit] =
+  ): ConnectionIO[StacCollection] =
     Applicative[ConnectionIO].pure {
       println(
         s"Inserting collection ${collection.title} with parent ${parentCollection map { _.title }} into catalog ${catalog.title}"
       )
+    } flatMap { _ =>
+      StacCollectionDao.insertStacCollection(collection, parentCollection map { _.id })
     }
 
   private def getPrefix(absPath: String): String = absPath.split("/").dropRight(1).mkString("/")

--- a/database/src/main/resources/migrations/V3__add_parent_collection.sql
+++ b/database/src/main/resources/migrations/V3__add_parent_collection.sql
@@ -1,0 +1,1 @@
+ALTER TABLE collections ADD COLUMN parent text REFERENCES collections(id);

--- a/database/src/main/scala/com/azavea/franklin/database/StacCollectionDao.scala
+++ b/database/src/main/scala/com/azavea/franklin/database/StacCollectionDao.scala
@@ -21,12 +21,13 @@ object StacCollectionDao {
     )).query[StacCollection].option
   }
 
-  def insertStacCollection(collection: StacCollection): ConnectionIO[StacCollection] = {
+  def insertStacCollection(collection: StacCollection,
+                           parentId: Option[String]): ConnectionIO[StacCollection] = {
 
     val insertFragment = fr"""
-      INSERT INTO collections (id, collection) 
+      INSERT INTO collections (id, parent, collection)
       VALUES
-      (${collection.id}, $collection)
+      (${collection.id}, $parentId, $collection)
       """
     insertFragment.update
       .withUniqueGeneratedKeys[StacCollection]("collection")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Versions {
   val DeclineVersion   = "0.6.2"
   val emoji            = "1.2.1"
   val Specs2Version    = "4.6.0"
-  val GeotrellisServer = "3.4.0-6-343db94f-SNAPSHOT"
+  val GeotrellisServer = "3.4.0-10-gc407568-SNAPSHOT"
   val PureConfig       = "0.12.1"
   val Log4CatsVersion  = "0.3.0"
   val LogbackVersion   = "1.2.3"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,6 +16,7 @@ object Versions {
   val Postgis          = "2.2.1"
   val ScapegoatVersion = "1.3.8"
   val CirceVersion     = "0.11.1"
+  val CirceFs2Version  = "0.11.0"
   val DoobieVersion    = "0.7.1"
   val Refined          = "0.9.3"
   val TapirVersion     = "0.10.1"
@@ -25,6 +26,7 @@ object Dependencies {
   val circeCore             = "io.circe"               %% "circe-core"               % Versions.CirceVersion
   val circeGeneric          = "io.circe"               %% "circe-generic"            % Versions.CirceVersion
   val circeRefined          = "io.circe"               %% "circe-refined"            % Versions.CirceVersion
+  val circeFs2              = "io.circe"               %% "circe-fs2"                % Versions.CirceFs2Version
   val decline               = "com.monovore"           %% "decline"                  % Versions.DeclineVersion
   val doobie                = "org.tpolecat"           %% "doobie-core"              % Versions.DoobieVersion
   val doobieHikari          = "org.tpolecat"           %% "doobie-hikari"            % Versions.DoobieVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Versions {
   val DeclineVersion   = "0.6.2"
   val emoji            = "1.2.1"
   val Specs2Version    = "4.6.0"
-  val GeotrellisServer = "3.4.0-10-gc407568-SNAPSHOT"
+  val GeotrellisServer = "3.4.0-8-g362e95f-SNAPSHOT"
   val PureConfig       = "0.12.1"
   val Log4CatsVersion  = "0.3.0"
   val LogbackVersion   = "1.2.3"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,6 @@ object Versions {
   val Specs2Version    = "4.6.0"
   val DoobieVersion    = "0.7.1"
   val Flyway           = "5.2.4"
-  val Fs2AWSVersion    = "2.28.6"
   val GeotrellisServer = "3.4.0-8-g362e95f-SNAPSHOT"
   val Http4sVersion    = "0.20.10"
   val Log4CatsVersion  = "0.3.0"
@@ -39,7 +38,6 @@ object Dependencies {
   val emoji                 = "com.lightbend"          %% "emoji"                    % Versions.emoji
   val doobieSpecs2          = "org.tpolecat"           %% "doobie-specs2"            % Versions.DoobieVersion % "test"
   val flyway                = "org.flywaydb"           % "flyway-core"               % Versions.Flyway
-  val fs2AWS                = "io.github.dmateusp"     % "fs2-aws_2.12"              % Versions.Fs2AWSVersion
   val geotrellisServer      = "com.azavea.geotrellis"  %% "geotrellis-server-stac"   % Versions.GeotrellisServer
   val http4s                = "org.http4s"             %% "http4s-blaze-server"      % Versions.Http4sVersion
   val http4sCirce           = "org.http4s"             %% "http4s-circe"             % Versions.Http4sVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,9 +7,8 @@ object Versions {
   val CirceFs2Version  = "0.11.0"
   val CirceVersion     = "0.11.1"
   val DeclineVersion   = "0.6.2"
-  val emoji            = "1.2.1"
-  val Specs2Version    = "4.6.0"
   val DoobieVersion    = "0.7.1"
+  val EmojiVersion     = "1.2.1"
   val Flyway           = "5.2.4"
   val GeotrellisServer = "3.4.0-8-g362e95f-SNAPSHOT"
   val Http4sVersion    = "0.20.10"
@@ -35,7 +34,7 @@ object Dependencies {
   val doobiePostgresCirce   = "org.tpolecat"           %% "doobie-postgres-circe"    % Versions.DoobieVersion
   val doobieRefined         = "org.tpolecat"           %% "doobie-refined"           % Versions.DoobieVersion
   val doobieScalatest       = "org.tpolecat"           %% "doobie-scalatest"         % Versions.DoobieVersion % "test"
-  val emoji                 = "com.lightbend"          %% "emoji"                    % Versions.emoji
+  val emoji                 = "com.lightbend"          %% "emoji"                    % Versions.EmojiVersion
   val doobieSpecs2          = "org.tpolecat"           %% "doobie-specs2"            % Versions.DoobieVersion % "test"
   val flyway                = "org.flywaydb"           % "flyway-core"               % Versions.Flyway
   val geotrellisServer      = "com.azavea.geotrellis"  %% "geotrellis-server-stac"   % Versions.GeotrellisServer

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,48 +4,53 @@ import sbt._
 
 // Versions
 object Versions {
-  val Http4sVersion    = "0.20.10"
+  val CirceFs2Version  = "0.11.0"
+  val CirceVersion     = "0.11.1"
   val DeclineVersion   = "0.6.2"
   val emoji            = "1.2.1"
   val Specs2Version    = "4.6.0"
+  val DoobieVersion    = "0.7.1"
+  val Flyway           = "5.2.4"
+  val Fs2AWSVersion    = "2.28.6"
   val GeotrellisServer = "3.4.0-8-g362e95f-SNAPSHOT"
-  val PureConfig       = "0.12.1"
+  val Http4sVersion    = "0.20.10"
   val Log4CatsVersion  = "0.3.0"
   val LogbackVersion   = "1.2.3"
-  val Flyway           = "5.2.4"
   val Postgis          = "2.2.1"
-  val ScapegoatVersion = "1.3.8"
-  val CirceVersion     = "0.11.1"
-  val CirceFs2Version  = "0.11.0"
-  val DoobieVersion    = "0.7.1"
+  val PureConfig       = "0.12.1"
   val Refined          = "0.9.3"
+  val ScapegoatVersion = "1.3.8"
+  val Specs2Version    = "4.6.0"
   val TapirVersion     = "0.10.1"
 }
 
 object Dependencies {
   val circeCore             = "io.circe"               %% "circe-core"               % Versions.CirceVersion
+  val circeFs2              = "io.circe"               %% "circe-fs2"                % Versions.CirceFs2Version
   val circeGeneric          = "io.circe"               %% "circe-generic"            % Versions.CirceVersion
   val circeRefined          = "io.circe"               %% "circe-refined"            % Versions.CirceVersion
-  val circeFs2              = "io.circe"               %% "circe-fs2"                % Versions.CirceFs2Version
   val decline               = "com.monovore"           %% "decline"                  % Versions.DeclineVersion
   val doobie                = "org.tpolecat"           %% "doobie-core"              % Versions.DoobieVersion
   val doobieHikari          = "org.tpolecat"           %% "doobie-hikari"            % Versions.DoobieVersion
   val doobiePostgres        = "org.tpolecat"           %% "doobie-postgres"          % Versions.DoobieVersion
   val doobiePostgresCirce   = "org.tpolecat"           %% "doobie-postgres-circe"    % Versions.DoobieVersion
-  val doobieSpecs2          = "org.tpolecat"           %% "doobie-specs2"            % Versions.DoobieVersion % "test"
   val doobieRefined         = "org.tpolecat"           %% "doobie-refined"           % Versions.DoobieVersion
   val doobieScalatest       = "org.tpolecat"           %% "doobie-scalatest"         % Versions.DoobieVersion % "test"
   val emoji                 = "com.lightbend"          %% "emoji"                    % Versions.emoji
+  val doobieSpecs2          = "org.tpolecat"           %% "doobie-specs2"            % Versions.DoobieVersion % "test"
+  val flyway                = "org.flywaydb"           % "flyway-core"               % Versions.Flyway
+  val fs2AWS                = "io.github.dmateusp"     % "fs2-aws_2.12"              % Versions.Fs2AWSVersion
+  val geotrellisServer      = "com.azavea.geotrellis"  %% "geotrellis-server-stac"   % Versions.GeotrellisServer
   val http4s                = "org.http4s"             %% "http4s-blaze-server"      % Versions.Http4sVersion
   val http4sCirce           = "org.http4s"             %% "http4s-circe"             % Versions.Http4sVersion
-  val http4sServer          = "org.http4s"             %% "http4s-blaze-server"      % Versions.Http4sVersion
   val http4sDsl             = "org.http4s"             %% "http4s-dsl"               % Versions.Http4sVersion
+  val http4sServer          = "org.http4s"             %% "http4s-blaze-server"      % Versions.Http4sVersion
   val log4cats              = "io.chrisdavenport"      %% "log4cats-slf4j"           % Versions.Log4CatsVersion
+  val logbackClassic        = "ch.qos.logback"         % "logback-classic"           % Versions.LogbackVersion
   val postgis               = "net.postgis"            % "postgis-jdbc"              % Versions.Postgis
-  val flyway                = "org.flywaydb"           % "flyway-core"               % Versions.Flyway
+  val pureConfig            = "com.github.pureconfig"  %% "pureconfig"               % Versions.PureConfig
   val refined               = "eu.timepit"             %% "refined"                  % Versions.Refined
   val refinedCats           = "eu.timepit"             %% "refined-cats"             % Versions.Refined
-  val logbackClassic        = "ch.qos.logback"         % "logback-classic"           % Versions.LogbackVersion
   val specs2Core            = "org.specs2"             %% "specs2-core"              % Versions.Specs2Version % "test"
   val tapir                 = "com.softwaremill.tapir" %% "tapir-core"               % Versions.TapirVersion
   val tapirCirce            = "com.softwaremill.tapir" %% "tapir-json-circe"         % Versions.TapirVersion
@@ -53,6 +58,4 @@ object Dependencies {
   val tapirOpenAPICirceYAML = "com.softwaremill.tapir" %% "tapir-openapi-circe-yaml" % Versions.TapirVersion
   val tapirOpenAPIDocs      = "com.softwaremill.tapir" %% "tapir-openapi-docs"       % Versions.TapirVersion
   val tapirSwaggerUIHttp4s  = "com.softwaremill.tapir" %% "tapir-swagger-ui-http4s"  % Versions.TapirVersion
-  val pureConfig            = "com.github.pureconfig"  %% "pureconfig"               % Versions.PureConfig
-  val geotrellisServer      = "com.azavea.geotrellis"  %% "geotrellis-server-stac"   % Versions.GeotrellisServer
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Versions {
   val DeclineVersion   = "0.6.2"
   val emoji            = "1.2.1"
   val Specs2Version    = "4.6.0"
-  val GeotrellisServer = "3.4.0-6-g7f8f646-SNAPSHOT"
+  val GeotrellisServer = "3.4.0-6-343db94f-SNAPSHOT"
   val PureConfig       = "0.12.1"
   val Log4CatsVersion  = "0.3.0"
   val LogbackVersion   = "1.2.3"


### PR DESCRIPTION
Overview
-----

This PR adds a STAC catalog importer that, if I did everything correctly, traverses a catalog, collections that are children of that catalog, and and collections that are children of those collections, adding items to our DB as it goes.

Notes
-----

It doesn't actually do the last part yet because I don't have a handy way to do db interaction for non-existent tables. ~Also it doesn't actually read a catalog yet, because I haven't implemented the methods for reading files / s3 paths into `fs2` streams. Hence, wip.~ s3 reading deferred to #21, docs happening separately

Testing
-----

- run it against the Panama export that you have locally

Closes #5