### PR TITLE
Include missing docs and fix spec

### DIFF
--- a/api/src/main/scala/com/azavea/franklin/Server.scala
+++ b/api/src/main/scala/com/azavea/franklin/Server.scala
@@ -15,6 +15,7 @@ import tapir.swagger.http4s.SwaggerHttp4s
 import cats.effect._
 import cats.implicits._
 import com.azavea.franklin.endpoints.{
+  CollectionEndpoints,
   CollectionItemEndpoints,
   LandingPageEndpoints,
   SearchEndpoints
@@ -75,7 +76,7 @@ $$$$
             transactionEc
           )
       }
-      allEndpoints      = LandingPageEndpoints.endpoints ++ CollectionItemEndpoints.endpoints ++ SearchEndpoints.endpoints
+      allEndpoints      = LandingPageEndpoints.endpoints ++ CollectionEndpoints.endpoints ++ CollectionItemEndpoints.endpoints ++ SearchEndpoints.endpoints
       docs              = allEndpoints.toOpenAPI("Franklin", "0.0.1")
       docRoutes         = new SwaggerHttp4s(docs.toYaml, "open-api", "spec.yaml").routes[IO]
       landingPageRoutes = new LandingPageService[IO].routes

--- a/api/src/main/scala/com/azavea/franklin/endpoints/SearchEndpoints.scala
+++ b/api/src/main/scala/com/azavea/franklin/endpoints/SearchEndpoints.scala
@@ -26,7 +26,7 @@ object SearchEndpoints {
       .in("search")
       .out(jsonBody[Json])
       .description("Search endpoint using POST for all collections")
-      .name("search-get")
+      .name("search-post")
 
   val endpoints = List(rootCatalog, searchGet, searchPost)
 


### PR DESCRIPTION
## Overview

This PR includes missing routes in the spec and fixes a name collision between the two search endpoints (operation names must be unique, says swagger editor).

## Testing

- assemble
- bring up server
- look at `:9090/spec.yaml` -- the collection routes should be included
- put http://localhost:9090/spec.yaml into https://editor.swagger.io/ -- it shouldn't be mad at you