### PR TITLE
Add google analytics

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -108,7 +108,10 @@ const siteConfig = {
   // You may provide arbitrary config keys to be used as needed by your
   // template. For example, if you need your repo's URL...
   repoUrl: "https://github.com/azavea/franklin",
-  customDocsPath: "api-docs/target/mdoc"
+  customDocsPath: "api-docs/target/mdoc",
+
+  // Google analytics ID
+  gaTrackingId: "UA-970854-35"
 };
 
 module.exports = siteConfig;


### PR DESCRIPTION
Pretty straightforward https://docusaurus.io/docs/en/site-config#gatrackingid-string

Testing:
Verify that google analytics loads. Since it's on localhost, it won't report anything on the dashboard.

Deployed to github pages, open in chrome to verify
![image](https://user-images.githubusercontent.com/4392704/69356322-4f449380-0c51-11ea-9ea5-cf59fdb5960e.png)

Closes https://github.com/azavea/raster-foundry-platform/issues/888