### PR TITLE
Add S3 imports for STAC datasets

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,17 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/enhancements---feature-requests.md
+++ b/.github/ISSUE_TEMPLATE/enhancements---feature-requests.md
@@ -1,0 +1,16 @@
+---
+name: Enhancements + Feature Requests
+about: Create an issue to log a possible improvement
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### Improvement
+
+What is it that could be improved and how it could be improved.
+
+### Notes + Context
+
+Any additional insights including possible approaches, user feedback, or historical context.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Overview
+
+Brief description of what this PR does, and why it is needed.
+
+### Checklist
+
+- [ ] New tests have been added or existing tests have been modified
+
+### Notes
+
+Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.
+
+### Testing Instructions
+
+- How to test this PR, prefer bulleted description, start after checking out this branch
+
+Closes #XXX (if applicable)

--- a/build.sbt
+++ b/build.sbt
@@ -63,6 +63,7 @@ lazy val applicationSettings = commonSettings ++ Seq(
 )
 
 lazy val applicationDependencies = Seq(
+  "com.amazonaws"               % "aws-java-sdk-core"         % Versions.AWSVersion,
   "com.amazonaws"               % "aws-java-sdk-s3"           % Versions.AWSVersion,
   "co.fs2"                      %% "fs2-core"                 % Versions.Fs2Version,
   "co.fs2"                      %% "fs2-io"                   % Versions.Fs2Version,

--- a/build.sbt
+++ b/build.sbt
@@ -49,6 +49,7 @@ lazy val root = (project in file("."))
 lazy val applicationSettings = commonSettings ++ Seq(
   name := "application",
   fork in run := true,
+  test in assembly := {},
   assemblyJarName in assembly := "franklin-api-assembly.jar",
   assemblyMergeStrategy in assembly := {
     case "reference.conf"                       => MergeStrategy.concat

--- a/build.sbt
+++ b/build.sbt
@@ -63,6 +63,7 @@ lazy val applicationSettings = commonSettings ++ Seq(
 )
 
 lazy val applicationDependencies = Seq(
+  "com.amazonaws"               % "aws-java-sdk-s3"           % Versions.AWSVersion,
   "co.fs2"                      %% "fs2-core"                 % Versions.Fs2Version,
   "co.fs2"                      %% "fs2-io"                   % Versions.Fs2Version,
   "com.azavea.stac4s"           %% "core"                     % Versions.Stac4SVersion,

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,5 +1,6 @@
 // Versions
 object Versions {
+  val AWSVersion            = "1.11.699"
   val CatsEffectVersion     = "2.0.0"
   val CatsScalacheckVersion = "0.2.0"
   val CatsVersion           = "2.1.0"


### PR DESCRIPTION
## Overview

This adds support for importing data directly from S3

### Checklist

- [x] New tests have been added or existing tests have been modified -- there weren't any existing tests and this didn't change much so I didn't add any

### Notes

I think the `ConnectionIO` part is a little _weird_ since I associate that with DB access and in this case it's reading data from S3. However, the changes here work within existing structures of the import process and works well I think.

This also adds github templates for PRs and issues.

### Testing instructions
 - Run `./scripts/update`
 - Start database: `docker-compose up -d database`
 - Drop any existing data (to avoid PK conflicts):
```
./scripts/dbshell
truncate table collections;
truncate table collection_items;
```
 - Run the following: `bloop run application -- import --db-host=localhost --catalog-root s3://demo-mlhub-earth/panama-water-features-jan-apr-2019/catalog.json`
 - Start server (`./scripts/server`) and check that data was added

Closes #21 
