### PR TITLE
Import label geojson data

### DIFF
--- a/application/src/main/scala/com/azavea/franklin/api/services/CollectionItemsService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/CollectionItemsService.scala
@@ -43,9 +43,10 @@ class CollectionItemsService[F[_]: Sync](
 ) extends Http4sDsl[F] {
 
   def listCollectionItems(collectionId: String): F[Either[Unit, Json]] = {
+    val decodedId = URLDecoder.decode(collectionId, StandardCharsets.UTF_8.toString)
     for {
       items <- StacItemDao.query
-        .filter(StacItemDao.collectionFilter(collectionId))
+        .filter(StacItemDao.collectionFilter(decodedId))
         .list
         .transact(xa)
     } yield {

--- a/application/src/main/scala/com/azavea/franklin/crawler/FeatureExtractor.scala
+++ b/application/src/main/scala/com/azavea/franklin/crawler/FeatureExtractor.scala
@@ -1,0 +1,72 @@
+package com.azavea.franklin.crawler
+
+import com.azavea.stac4s._
+import io.circe.JsonObject
+import eu.timepit.refined.types.string.NonEmptyString
+import geotrellis.vector.{Feature, Geometry}
+import geotrellis.vector.methods.Implicits._
+
+import java.net.URLEncoder
+import com.azavea.stac4s.StacLink
+
+import java.util.UUID
+import com.azavea.stac4s.TwoDimBbox
+import java.nio.charset.StandardCharsets
+
+object FeatureExtractor {
+
+  def toItem(
+      feature: Feature[Geometry, JsonObject],
+      forItem: StacItem,
+      inCollection: StacCollection,
+      serverHost: NonEmptyString
+  ): StacItem = {
+    val newItemId = s"${UUID.randomUUID}"
+
+    val collectionHref =
+      s"$serverHost/collections/${URLEncoder.encode(inCollection.id, StandardCharsets.UTF_8.toString)}"
+    val sourceItemHref =
+      s"$collectionHref/items/${URLEncoder.encode(forItem.id, StandardCharsets.UTF_8.toString)}"
+    val selfHref = s"$collectionHref/items/$newItemId"
+
+    val collectionLink = StacLink(
+      collectionHref,
+      StacLinkType.Parent,
+      Some(`application/json`),
+      title = Some("Source item's original collection"),
+      Nil
+    )
+
+    val sourceItemLink = StacLink(
+      sourceItemHref,
+      StacLinkType.Source,
+      Some(`application/json`),
+      title = Some("Source item"),
+      Nil
+    )
+
+    val selfLink = StacLink(
+      selfHref,
+      StacLinkType.Self,
+      Some(`application/json`),
+      None,
+      Nil
+    )
+
+    val featureExtent = feature.geom.extent
+
+    StacItem(
+      s"${UUID.randomUUID}",
+      "0.9.0",
+      Nil,
+      "Feature",
+      feature.geom,
+      TwoDimBbox(featureExtent.xmin, featureExtent.ymin, featureExtent.xmax, featureExtent.ymax),
+      links = List(collectionLink, sourceItemLink, selfLink),
+      assets = Map.empty,
+      collection = Some(inCollection.id),
+      properties = feature.data
+    )
+  }
+
+}

--- a/application/src/main/scala/com/azavea/franklin/crawler/FeatureExtractor.scala
+++ b/application/src/main/scala/com/azavea/franklin/crawler/FeatureExtractor.scala
@@ -1,17 +1,16 @@
 package com.azavea.franklin.crawler
 
+import com.azavea.stac4s.StacLink
+import com.azavea.stac4s.TwoDimBbox
 import com.azavea.stac4s._
-import io.circe.JsonObject
 import eu.timepit.refined.types.string.NonEmptyString
-import geotrellis.vector.{Feature, Geometry}
 import geotrellis.vector.methods.Implicits._
+import geotrellis.vector.{Feature, Geometry}
+import io.circe.JsonObject
 
 import java.net.URLEncoder
-import com.azavea.stac4s.StacLink
-
-import java.util.UUID
-import com.azavea.stac4s.TwoDimBbox
 import java.nio.charset.StandardCharsets
+import java.util.UUID
 
 object FeatureExtractor {
 

--- a/application/src/main/scala/com/azavea/franklin/crawler/StacImport.scala
+++ b/application/src/main/scala/com/azavea/franklin/crawler/StacImport.scala
@@ -10,18 +10,18 @@ import doobie.ConnectionIO
 import doobie.implicits._
 import doobie.util.transactor.Transactor
 import eu.timepit.refined.types.string.NonEmptyString
-import geotrellis.vector.io.json._
 import geotrellis.vector.io.json.Implicits._
+import geotrellis.vector.io.json._
+import geotrellis.vector.{Feature, Geometry}
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import io.circe.Decoder
+import io.circe.JsonObject
 import io.circe.parser.decode
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
-import io.circe.JsonObject
-import geotrellis.vector.{Feature, Geometry}
 
 class StacImport(val catalogRoot: String, serverHost: NonEmptyString) {
 

--- a/application/src/main/scala/com/azavea/franklin/crawler/StacImport.scala
+++ b/application/src/main/scala/com/azavea/franklin/crawler/StacImport.scala
@@ -36,6 +36,8 @@ class StacImport(val catalogRoot: String, serverHost: NonEmptyString) {
   private def getPrefix(absPath: String): String = absPath.split("/").dropRight(1).mkString("/")
 
   private def makeAbsPath(from: String, relPath: String): String = {
+    // don't try to relativize links that start with s3 -- the string splitting
+    // does _weird_ stuff :(
     if (relPath.startsWith("s3://")) {
       relPath
     } else {
@@ -60,7 +62,6 @@ class StacImport(val catalogRoot: String, serverHost: NonEmptyString) {
   }
 
   private def readPath[T: Decoder](path: String): IO[T] = {
-    println(s"About to read: $path")
     val str = if (path.startsWith("s3://")) {
       readFromS3(path)
     } else {

--- a/application/src/main/scala/com/azavea/franklin/crawler/StacImport.scala
+++ b/application/src/main/scala/com/azavea/franklin/crawler/StacImport.scala
@@ -143,7 +143,7 @@ class StacImport(val catalogRoot: String, serverHost: NonEmptyString) {
             val labelCollection = StacCollection(
               "0.9.0",
               Nil,
-              s"${forItem.id}-labels-$idx",
+              s"${forItem.id}-labels-${idx + 1}",
               Some(s"${forItem.id} Labels"),
               s"Labels for ${forItem.id}'s ${assetKey} asset",
               Nil,
@@ -165,7 +165,7 @@ class StacImport(val catalogRoot: String, serverHost: NonEmptyString) {
             }
 
             val newAsset = Map(
-              s"Label collection $idx" -> StacItemAsset(
+              s"Label collection ${idx + 1}" -> StacItemAsset(
                 s"$serverHost/collections/${URLEncoder
                   .encode(labelCollection.id, StandardCharsets.UTF_8.toString)}",
                 None,

--- a/build.sbt
+++ b/build.sbt
@@ -142,6 +142,7 @@ lazy val applicationDependencies = Seq(
   "org.tpolecat"                %% "doobie-scalatest"         % Versions.DoobieVersion % "test",
   "org.tpolecat"                %% "doobie-specs2"            % Versions.DoobieVersion % "test",
   "org.typelevel"               %% "cats-core"                % Versions.CatsVersion,
+  "org.typelevel"               %% "cats-kernel"              % Versions.CatsVersion,
   "org.typelevel"               %% "cats-effect"              % Versions.CatsEffectVersion,
   "org.typelevel"               %% "cats-free"                % Versions.CatsVersion
 )


### PR DESCRIPTION
## Overview

This PR imports geojson data for items that have geojson assets. It puts the new data in a collection where each feature from the geojson is an item and updates the item to point to 

### Checklist

- ~New tests have been added or existing tests have been modified~ someday, tests...

### Testing Instructions

- truncate your `collections` and `collection_items` tables
- re-import the Berlin data -- I added a geojson of random boxes to the assets for one of the items and stored it with the collection
- check out the predictions item: http://localhost:9090/collections/berlin/items/berlin+building+predictions -- it should have an asset pointing to a collection called "Label collection 1"
- click the link -- it should work
- navigate around in the collection -- it should work