### PR TITLE
Render single band imagery

### DIFF
--- a/application/src/main/scala/com/azavea/franklin/api/endpoints/TileEndpoints.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/endpoints/TileEndpoints.scala
@@ -11,6 +11,7 @@ import sttp.model.StatusCode.{NotFound => NF}
 import sttp.tapir._
 import sttp.tapir.codec.refined._
 import sttp.tapir.json.circe._
+import eu.timepit.refined.types.numeric.NonNegInt
 
 class TileEndpoints(enableTiles: Boolean) {
 
@@ -34,6 +35,7 @@ class TileEndpoints(enableTiles: Boolean) {
       .and(query[Option[Int]]("blueBand"))
       .and(query[Option[Quantile]]("upperQuantile"))
       .and(query[Option[Quantile]]("lowerQuantile"))
+      .and(query[Option[NonNegInt]]("singleBand"))
       .mapTo(ItemRasterTileRequest)
 
   val itemRasterTileEndpoint: Endpoint[ItemRasterTileRequest, NotFound, Array[Byte], Nothing] =

--- a/application/src/main/scala/com/azavea/franklin/api/endpoints/TileEndpoints.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/endpoints/TileEndpoints.scala
@@ -6,12 +6,12 @@ import com.azavea.franklin.datamodel.{
   Quantile
 }
 import com.azavea.franklin.error.NotFound
+import eu.timepit.refined.types.numeric.NonNegInt
 import io.circe.Json
 import sttp.model.StatusCode.{NotFound => NF}
 import sttp.tapir._
 import sttp.tapir.codec.refined._
 import sttp.tapir.json.circe._
-import eu.timepit.refined.types.numeric.NonNegInt
 
 class TileEndpoints(enableTiles: Boolean) {
 

--- a/application/src/main/scala/com/azavea/franklin/api/services/CollectionItemsService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/CollectionItemsService.scala
@@ -50,9 +50,14 @@ class CollectionItemsService[F[_]: Sync](
         .list
         .transact(xa)
     } yield {
+      val updatedItems = enableTiles match {
+        case true =>
+          items map { item => item.addTilesLink(apiHost, collectionId, item.id) }
+        case _ => items
+      }
       val response = Json.obj(
         ("type", Json.fromString("FeatureCollection")),
-        ("features", items.asJson)
+        ("features", updatedItems.asJson)
       )
       Either.right(response)
     }

--- a/application/src/main/scala/com/azavea/franklin/api/services/TileService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/TileService.scala
@@ -17,9 +17,10 @@ import com.azavea.franklin.tile._
 import doobie._
 import doobie.implicits._
 import eu.timepit.refined.types.string.NonEmptyString
-import geotrellis.raster.{io => _, _}
-import geotrellis.raster.render.{Implicits => RenderImplicits}
+import geotrellis.raster.geotiff.GeoTiffRasterSource
 import geotrellis.raster.render.ColorRamps.greyscale
+import geotrellis.raster.render.{Implicits => RenderImplicits}
+import geotrellis.raster.{io => _, _}
 import geotrellis.server.LayerTms
 import geotrellis.server._
 import io.circe.Json
@@ -30,7 +31,6 @@ import sttp.tapir.server.http4s._
 
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
-import geotrellis.raster.geotiff.GeoTiffRasterSource
 
 class TileService[F[_]: Sync: LiftIO](
     serverHost: NonEmptyString,

--- a/application/src/main/scala/com/azavea/franklin/api/services/TileService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/TileService.scala
@@ -103,7 +103,7 @@ class TileService[F[_]: Sync: LiftIO](
               val greyscaleRamp = greyscale(255)
               val hist          = histograms(0)
               val breaks        = hist.quantileBreaks(100)
-              greyscaleRamp.toColorMap(Vector(breaks.min, breaks.max))
+              greyscaleRamp.toColorMap(breaks)
             }
             val renderedTile = cmap.render(mbt.band(0))
             Either.right(renderedTile.renderPng.bytes)

--- a/application/src/main/scala/com/azavea/franklin/api/services/TileService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/TileService.scala
@@ -18,6 +18,8 @@ import doobie._
 import doobie.implicits._
 import eu.timepit.refined.types.string.NonEmptyString
 import geotrellis.raster.{io => _, _}
+import geotrellis.raster.render.{Implicits => RenderImplicits}
+import geotrellis.raster.render.ColorRamps.greyscale
 import geotrellis.server.LayerTms
 import geotrellis.server._
 import io.circe.Json
@@ -28,6 +30,7 @@ import sttp.tapir.server.http4s._
 
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
+import geotrellis.raster.geotiff.GeoTiffRasterSource
 
 class TileService[F[_]: Sync: LiftIO](
     serverHost: NonEmptyString,
@@ -36,7 +39,8 @@ class TileService[F[_]: Sync: LiftIO](
 )(
     implicit cs: ContextShift[F],
     csIO: ContextShift[IO]
-) extends Http4sDsl[F] {
+) extends Http4sDsl[F]
+    with RenderImplicits {
 
   import CogAssetNodeImplicits._
 
@@ -59,15 +63,22 @@ class TileService[F[_]: Sync: LiftIO](
       )
       cogAssetNode = CogAssetNode(
         cogAsset,
-        tileRequest.bands
+        tileRequest.singleBand map { sb =>
+          List(sb.value)
+        } getOrElse {
+          tileRequest.bands
+        }
       )
       histograms <- EitherT.liftF[F, NF, List[Histogram[Int]]](
         LiftIO[F].liftIO(cogAssetNode.getHistograms)
       )
+      rs <- EitherT.liftF[F, NF, GeoTiffRasterSource] {
+        LiftIO[F].liftIO(cogAssetNode.getRasterSource)
+      }
       tile <- EitherT {
         val eval = LayerTms.identity(cogAssetNode)
         LiftIO[F].liftIO(eval(z, x, y).map {
-          case Valid(mbt: MultibandTile) => {
+          case Valid(mbt: MultibandTile) if mbt.bandCount > 1 => {
             Either.right {
               val bands = mbt.bands.zip(histograms).map {
                 case (tile, histogram) =>
@@ -87,6 +98,15 @@ class TileService[F[_]: Sync: LiftIO](
                 .bytes
             }
           }
+          case Valid(mbt: MultibandTile) if mbt.bandCount == 1 =>
+            val cmap = rs.tiff.options.colorMap getOrElse {
+              val greyscaleRamp = greyscale(255)
+              val hist          = histograms(0)
+              val breaks        = hist.quantileBreaks(100)
+              greyscaleRamp.toColorMap(Vector(breaks(0), breaks(99)))
+            }
+            val renderedTile = cmap.render(mbt.band(0))
+            Either.right(renderedTile.renderPng.bytes)
           case Invalid(e) => Either.left(NF(s"Could not produce tile: $e"))
         })
       }

--- a/application/src/main/scala/com/azavea/franklin/api/services/TileService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/TileService.scala
@@ -103,7 +103,7 @@ class TileService[F[_]: Sync: LiftIO](
               val greyscaleRamp = greyscale(255)
               val hist          = histograms(0)
               val breaks        = hist.quantileBreaks(100)
-              greyscaleRamp.toColorMap(Vector(breaks(0), breaks(99)))
+              greyscaleRamp.toColorMap(Vector(breaks.min, breaks.max))
             }
             val renderedTile = cmap.render(mbt.band(0))
             Either.right(renderedTile.renderPng.bytes)

--- a/application/src/main/scala/com/azavea/franklin/datamodel/TileRequest.scala
+++ b/application/src/main/scala/com/azavea/franklin/datamodel/TileRequest.scala
@@ -1,5 +1,7 @@
 package com.azavea.franklin.datamodel
 
+import eu.timepit.refined.types.numeric.NonNegInt
+
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
 
@@ -24,7 +26,8 @@ case class ItemRasterTileRequest(
     greenBandOption: Option[Int],
     blueBandOption: Option[Int],
     upperQuantileOption: Option[Quantile],
-    lowerQuantileOption: Option[Quantile]
+    lowerQuantileOption: Option[Quantile],
+    singleBand: Option[NonNegInt]
 ) extends TileMatrixRequest {
 
   val collection = urlDecode(collectionRaw)


### PR DESCRIPTION
## Overview

This PR adds a prioritized query parameter for a single band render called `singleBand`. It's prioritized in the sense that it will override rgb query params if both are present.

### Checklist

- ~New tests have been added or existing tests have been modified~ they have not

## Notes

For `eo` items, we should be able to infer whether we need a single band parameter if the length of the bands is 1. We should consider an issue to add types / codecs for the eo extension so that we can try to figure out whether the single band parameter is necessary when creating the tile links.

### Testing Instructions

- bring up your db, truncate tables
- re-import the Berlin data: `bloop run application -- import --catalog-root s3://rasterfoundry-development-data-us-east-1/berlin-catalog/catalog.json --db-host localhost` (it's necessary because I created an asset with the label data tif with a color map)
- `./scripts/server --with-tiles`
- head over to geojson.io, turn on the satellite layer, and zoom to Berlin
- add a tile layer with the following URL: http://localhost:9090/tiles/collections/berlin/items/berlin+building+labels/WebMercatorQuad/{z}/{x}/{y}/?asset=cmap_bldg_labels&singleBand=0, then zoom to Berlin
- it should have nice blue and red colors that more or less match what's going on in the satellite data
- add another tile layer with the following URL: http://localhost:9090/tiles/collections/berlin/items/berlin+building+labels/WebMercatorQuad/{z}/{x}/{y}/?asset=bldg_labels&singleBand=0 (**cmap** has been removed from the asset)
- it should look like the previous tile layer but in greyscale

Closes #215 
