### PR TITLE
Downgrade deployed/published container

### DIFF
--- a/application/Dockerfile
+++ b/application/Dockerfile
@@ -9,4 +9,4 @@ COPY ./target/scala-2.12/franklin-api-assembly.jar /var/lib/franklin/
 USER franklin
 WORKDIR /var/lib/franklin
 
-ENTRYPOINT ["java", "-jar", "franklin-api-assembly.jar"]
+ENTRYPOINT ["java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-jar", "franklin-api-assembly.jar"]

--- a/application/Dockerfile
+++ b/application/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre-slim
+FROM openjdk:8-jre-slim
 
 RUN \
       addgroup --system franklin \


### PR DESCRIPTION
## Overview

This PR downgrades the JVM in the deployed / published container so that tile rendering works. It's follow up to similar problems encountered in the Raster Foundry tile server / API containers.

### Checklist

- ~New tests have been added or existing tests have been modified~

### Notes

Discovered in testing raster-foundry/stac-viewer#16 -- when trying to view tiles I hit the "unexpected end of content" error we've seen elsewhere using the container published for 140d59a

### Testing Instructions

- use the container referred to above to test the linked PR above
- observe the unexpected content length error
- check whether you agree that this JRE downgrade basically matches this PR's downgrades raster-foundry/raster-foundry#5401