### PR TITLE
Support query extension

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - image: circleci/openjdk:11-jdk
         environment:
           - POSTGRES_URL=jdbc:postgresql://database.service.internal/
-      - image: quay.io/azavea/postgis:2.3-postgres9.6-slim
+      - image: quay.io/azavea/postgis:3-postgres12.2-slim
         name: database.service.internal
         environment:
           - POSTGRES_USER=franklin

--- a/application/src/main/scala/com/azavea/franklin/api/endpoints/SearchEndpoints.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/endpoints/SearchEndpoints.scala
@@ -30,6 +30,8 @@ object SearchEndpoints {
             Option[String]
         )) => {
           val (temporalExtent, bbox, collections, ids, limit, next) = tup
+          // query is empty here because entering query extension fields in url params is
+          // completely insane
           SearchFilters(
             bbox,
             temporalExtent,
@@ -37,7 +39,8 @@ object SearchEndpoints {
             collections getOrElse Nil,
             ids getOrElse Nil,
             limit,
-            next
+            next,
+            Map.empty
           )
         }
       )(sf => (sf.datetime, sf.bbox, Some(sf.collections), Some(sf.items), sf.limit, sf.next))

--- a/application/src/main/scala/com/azavea/franklin/database/Filterables.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/Filterables.scala
@@ -8,6 +8,7 @@ import doobie.implicits.legacy.instant._
 import doobie.postgres.circe.jsonb.implicits._
 import doobie.refined.implicits._
 import doobie.{Query => _, _}
+import io.circe.syntax._
 import geotrellis.vector.Projected
 
 trait FilterHelpers {
@@ -53,6 +54,7 @@ trait FilterHelpers {
         case Contains(substring) =>
           Fragment.const(s"strpos(item ->> '$field', '$substring') > 0")
         case In(values) => Fragments.in(fieldFragment, values)
+        case Superset(values) => fieldFragment ++ fr"@> ${values.asJson}"
       }
     }
   }

--- a/application/src/main/scala/com/azavea/franklin/database/Filterables.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/Filterables.scala
@@ -1,13 +1,12 @@
 package com.azavea.franklin.database
 
-import com.azavea.franklin.datamodel._
-
 import cats.implicits._
+import com.azavea.franklin.datamodel._
 import com.azavea.stac4s.TemporalExtent
-import doobie.{Query => _, _}
 import doobie.implicits._
 import doobie.implicits.legacy.instant._
 import doobie.refined.implicits._
+import doobie.{Query => _, _}
 import geotrellis.vector.Projected
 
 trait FilterHelpers {

--- a/application/src/main/scala/com/azavea/franklin/database/Filterables.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/Filterables.scala
@@ -8,8 +8,8 @@ import doobie.implicits.legacy.instant._
 import doobie.postgres.circe.jsonb.implicits._
 import doobie.refined.implicits._
 import doobie.{Query => _, _}
-import io.circe.syntax._
 import geotrellis.vector.Projected
+import io.circe.syntax._
 
 trait FilterHelpers {
 
@@ -53,7 +53,7 @@ trait FilterHelpers {
           Fragment.const(s"right(item ->> '$field', ${postfix.value.length})") ++ fr"= $postfix"
         case Contains(substring) =>
           Fragment.const(s"strpos(item ->> '$field', '$substring') > 0")
-        case In(values) => Fragments.in(fieldFragment, values)
+        case In(values)       => Fragments.in(fieldFragment, values)
         case Superset(values) => fieldFragment ++ fr"@> ${values.asJson}"
       }
     }

--- a/application/src/main/scala/com/azavea/franklin/database/Filterables.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/Filterables.scala
@@ -1,10 +1,13 @@
 package com.azavea.franklin.database
 
+import com.azavea.franklin.datamodel._
+
 import cats.implicits._
 import com.azavea.stac4s.TemporalExtent
-import doobie._
+import doobie.{Query => _, _}
 import doobie.implicits._
 import doobie.implicits.legacy.instant._
+import doobie.refined.implicits._
 import geotrellis.vector.Projected
 
 trait FilterHelpers {
@@ -22,6 +25,40 @@ trait FilterHelpers {
         case _ :: Some(end) :: _ =>
           Some(fr"(item #>> '{properties, datetime}') :: TIMESTAMPTZ <= $end")
         case _ => None
+      }
+    }
+  }
+
+  implicit class QueryWithFilter(query: Query) {
+
+    def toFilterFragment(field: String) = {
+      val fieldFragment        = Fragment.const(s"item -> 'properties' ->> '$field'")
+      val numericFieldFragment = fieldFragment ++ fr":: float8"
+      query match {
+        case EqualsString(value) =>
+          fieldFragment ++ fr"= $value"
+        case EqualsNumber(value) =>
+          numericFieldFragment ++ fr"= $value"
+        case NotEqualToString(value) =>
+          fieldFragment ++ fr"<> $value"
+        case NotEqualToNumber(value) =>
+          numericFieldFragment ++ fr"<> $value"
+        case GreaterThan(floor) =>
+          numericFieldFragment ++ fr"> $floor"
+        case GreaterThanEqual(floor) =>
+          numericFieldFragment ++ fr"$floor"
+        case LessThan(ceiling) =>
+          numericFieldFragment ++ fr"< $ceiling"
+        case LessThanEqual(ceiling) =>
+          numericFieldFragment ++ fr"<= $ceiling"
+        case StartsWith(prefix) =>
+          Fragment.const(s"starts_with(item ->> '$field', '$prefix')")
+        case EndsWith(postfix) =>
+          Fragment.const(s"right(item ->> '$field', ${postfix.value.length})") ++ fr"= $postfix"
+        case Contains(substring) =>
+          Fragment.const(s"strpos(item ->> '$field', '$substring') > 0")
+        case InStrings(values) => Fragments.in(fieldFragment, values)
+        case InNumbers(values) => Fragments.in(numericFieldFragment, values)
       }
     }
   }
@@ -53,7 +90,7 @@ trait Filterables extends GeotrellisWktMeta with FilterHelpers {
   implicit val searchFilter: Filterable[Any, SearchFilters] =
     Filterable[Any, SearchFilters] { searchFilters: SearchFilters =>
       val collectionsFilter: Option[Fragment] = searchFilters.collections.toNel
-        .map(collections => Fragments.in(fr"item #>> '{properties, collection}'", collections))
+        .map(collections => Fragments.in(fr"item ->> 'collection'", collections))
       val idFilter: Option[Fragment] =
         searchFilters.items.toNel.map(ids => Fragments.in(fr"id", ids))
 
@@ -69,7 +106,16 @@ trait Filterables extends GeotrellisWktMeta with FilterHelpers {
       }
       val temporalExtentFilter: Option[Fragment] =
         searchFilters.datetime.flatMap(_.toFilterFragment)
-      List(collectionsFilter, idFilter, geometryFilter, bboxFilter, temporalExtentFilter)
+
+      val queryExtFilter =
+        (searchFilters.query.map {
+          case (k, queries) =>
+            Fragments.and(
+              queries.map(_.toFilterFragment(k)): _*
+            )
+        }).toList map { Some(_) }
+
+      List(collectionsFilter, idFilter, geometryFilter, bboxFilter, temporalExtentFilter) ++ queryExtFilter
     }
 }
 

--- a/application/src/main/scala/com/azavea/franklin/database/Filterables.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/Filterables.scala
@@ -32,7 +32,7 @@ trait FilterHelpers {
 
     def toFilterFragment(field: String) = {
       val fieldFragment        = Fragment.const(s"item -> 'properties' ->> '$field'")
-      val numericFieldFragment = fieldFragment ++ fr":: float8"
+      val numericFieldFragment = fr"(" ++ fieldFragment ++ fr"):: float8"
       query match {
         case EqualsString(value) =>
           fieldFragment ++ fr"= $value"
@@ -45,7 +45,7 @@ trait FilterHelpers {
         case GreaterThan(floor) =>
           numericFieldFragment ++ fr"> $floor"
         case GreaterThanEqual(floor) =>
-          numericFieldFragment ++ fr"$floor"
+          numericFieldFragment ++ fr">= $floor"
         case LessThan(ceiling) =>
           numericFieldFragment ++ fr"< $ceiling"
         case LessThanEqual(ceiling) =>

--- a/application/src/main/scala/com/azavea/franklin/database/SearchFilters.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/SearchFilters.scala
@@ -2,7 +2,6 @@ package com.azavea.franklin.database
 
 import com.azavea.franklin.datamodel.Query
 import com.azavea.stac4s.{Bbox, TemporalExtent}
-
 import geotrellis.vector.Geometry
 import geotrellis.vector.{io => _, _}
 import io.circe.generic.semiauto._

--- a/application/src/main/scala/com/azavea/franklin/database/SearchFilters.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/SearchFilters.scala
@@ -1,6 +1,8 @@
 package com.azavea.franklin.database
 
+import com.azavea.franklin.datamodel.Query
 import com.azavea.stac4s.{Bbox, TemporalExtent}
+
 import geotrellis.vector.Geometry
 import geotrellis.vector.{io => _, _}
 import io.circe.generic.semiauto._
@@ -13,7 +15,8 @@ final case class SearchFilters(
     collections: List[String],
     items: List[String],
     limit: Option[Int],
-    next: Option[String]
+    next: Option[String],
+    query: Map[String, List[Query]]
 ) {
   val page = Page(limit, next)
 }
@@ -31,6 +34,7 @@ object SearchFilters {
         itemsOption       <- c.downField("items").as[Option[List[String]]]
         limit             <- c.downField("limit").as[Option[Int]]
         next              <- c.downField("next").as[Option[String]]
+        query             <- c.get[Map[String, List[Query]]]("query")
       } yield {
         SearchFilters(
           bbox,
@@ -39,7 +43,8 @@ object SearchFilters {
           collectionsOption.getOrElse(List.empty),
           itemsOption.getOrElse(List.empty),
           limit,
-          next
+          next,
+          query
         )
       }
   }

--- a/application/src/main/scala/com/azavea/franklin/database/SearchFilters.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/SearchFilters.scala
@@ -35,7 +35,6 @@ object SearchFilters {
         next              <- c.downField("next").as[Option[String]]
         query             <- c.get[Map[String, List[Query]]]("query")
       } yield {
-        println(s"Query is: $query")
         SearchFilters(
           bbox,
           datetime,

--- a/application/src/main/scala/com/azavea/franklin/database/SearchFilters.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/SearchFilters.scala
@@ -35,6 +35,7 @@ object SearchFilters {
         next              <- c.downField("next").as[Option[String]]
         query             <- c.get[Map[String, List[Query]]]("query")
       } yield {
+        println(s"Query is: $query")
         SearchFilters(
           bbox,
           datetime,

--- a/application/src/main/scala/com/azavea/franklin/datamodel/Query.scala
+++ b/application/src/main/scala/com/azavea/franklin/datamodel/Query.scala
@@ -8,16 +8,17 @@ import io.circe.syntax._
 
 sealed abstract class Query
 
-case class Equals(value: Json)                 extends Query
-case class NotEqualTo(value: Json)             extends Query
-case class GreaterThan(floor: Json)            extends Query
-case class GreaterThanEqual(floor: Json)       extends Query
-case class LessThan(ceiling: Json)             extends Query
-case class LessThanEqual(ceiling: Json)        extends Query
-case class StartsWith(prefix: NonEmptyString)  extends Query
-case class EndsWith(postfix: NonEmptyString)   extends Query
-case class Contains(substring: NonEmptyString) extends Query
-case class In(values: NonEmptyVector[Json])    extends Query
+case class Equals(value: Json)                    extends Query
+case class NotEqualTo(value: Json)                extends Query
+case class GreaterThan(floor: Json)               extends Query
+case class GreaterThanEqual(floor: Json)          extends Query
+case class LessThan(ceiling: Json)                extends Query
+case class LessThanEqual(ceiling: Json)           extends Query
+case class StartsWith(prefix: NonEmptyString)     extends Query
+case class EndsWith(postfix: NonEmptyString)      extends Query
+case class Contains(substring: NonEmptyString)    extends Query
+case class In(values: NonEmptyVector[Json])       extends Query
+case class Superset(values: NonEmptyVector[Json]) extends Query
 
 object Query {
 
@@ -73,6 +74,11 @@ object Query {
           json.asArray flatMap { _.toNev } map { vec => In(vec) },
           errMessage(op, json)
         )
+      case (op @ "superset", json) =>
+        Either.fromOption(
+          json.asArray flatMap { _.toNev } map { vec => Superset(vec) },
+          errMessage(op, json)
+        )
       case (k, _) => Left(s"$k is not a valid operator")
     })
 
@@ -91,6 +97,7 @@ object Query {
           case EndsWith(postfix)       => "endsWith"   -> postfix.asJson
           case Contains(substring)     => "contains"   -> substring.asJson
           case In(values)              => "in"         -> values.asJson
+          case Superset(values)        => "superset"   -> values.asJson
         }): _*
       ).asJson
   }

--- a/application/src/main/scala/com/azavea/franklin/datamodel/Query.scala
+++ b/application/src/main/scala/com/azavea/franklin/datamodel/Query.scala
@@ -93,9 +93,24 @@ object Query {
 
   implicit val encQuery: Encoder[List[Query]] = new Encoder[List[Query]] {
 
-    def apply(queries: List[Query]): Json = queries match {
-      case _ => ().asJson
-    }
+    def apply(queries: List[Query]): Json =
+      Map(
+        (queries map {
+          case EqualsString(value)     => "eq"         -> value.asJson
+          case EqualsNumber(value)     => "eq"         -> value.asJson
+          case NotEqualToString(value) => "neq"        -> value.asJson
+          case NotEqualToNumber(value) => "neq"        -> value.asJson
+          case GreaterThan(floor)      => "gt"         -> floor.asJson
+          case GreaterThanEqual(floor) => "gte"        -> floor.asJson
+          case LessThan(ceiling)       => "lt"         -> ceiling.asJson
+          case LessThanEqual(ceiling)  => "lte"        -> ceiling.asJson
+          case StartsWith(prefix)      => "startsWith" -> prefix.asJson
+          case EndsWith(postfix)       => "endsWith"   -> postfix.asJson
+          case Contains(substring)     => "contains"   -> substring.asJson
+          case InStrings(values)       => "in"         -> values.asJson
+          case InNumbers(values)       => "in"         -> values.asJson
+        }): _*
+      ).asJson
   }
 
   implicit val decQueries: Decoder[List[Query]] = Decoder[JsonObject].emap { jsonObj =>

--- a/application/src/main/scala/com/azavea/franklin/datamodel/Query.scala
+++ b/application/src/main/scala/com/azavea/franklin/datamodel/Query.scala
@@ -1,0 +1,60 @@
+package com.azavea.franklin.datamodel
+
+import cats.data.NonEmptyList
+import cats.implicits._
+import eu.timepit.refined.types.string.NonEmptyString
+import io.circe._
+
+sealed abstract class Query
+
+case class EqualsString(value: NonEmptyString)             extends Query
+case class EqualsNumber(value: Double)                     extends Query
+case class NotEqualToString(value: NonEmptyString)         extends Query
+case class NotEqualToNumber(value: Double)                 extends Query
+case class GreaterThan(floor: Double)                      extends Query
+case class GreaterThanEqual(floor: Double)                 extends Query
+case class LessThan(ceiling: Double)                       extends Query
+case class LessThanEqual(ceiling: Double)                  extends Query
+case class StartsWith(prefix: NonEmptyString)              extends Query
+case class EndsWith(postfix: NonEmptyString)               extends Query
+case class Contains(substring: NonEmptyString)             extends Query
+case class InStrings(values: NonEmptyList[NonEmptyString]) extends Query
+case class InNumbers(values: NonEmptyList[Double])         extends Query
+
+object Query {
+
+  private def fromString(s: String, f: NonEmptyString => Query) =
+    NonEmptyString.from(s).toOption.map(f)
+
+  def queriesFromMap(unparsed: Map[String, Json]) = unparsed flatMap {
+    case ("eq", json) =>
+      json.asString map { fromString(_, EqualsString.apply) } orElse {
+        json.asNumber map { num => EqualsNumber(num.toDouble) }
+      }
+    case ("neq", json) =>
+      json.asString map { fromString(_, NotEqualToString.apply) } orElse {
+        json.asNumber map { num => NotEqualToNumber(num.toDouble) }
+      }
+    case ("lt", json)         => json.asNumber map { num => LessThan(num.toDouble) }
+    case ("lte", json)        => json.asNumber map { num => LessThanEqual(num.toDouble) }
+    case ("gt", json)         => json.asNumber map { num => GreaterThan(num.toDouble) }
+    case ("gte", json)        => json.asNumber map { num => GreaterThanEqual(num.toDouble) }
+    case ("startsWith", json) => json.asString flatMap { fromString(_, StartsWith.apply) }
+    case ("endsWith", json)   => json.asString flatMap { fromString(_, EndsWith.apply) }
+    case ("contains", json)   => json.asString flatMap { fromString(_, Contains.apply) }
+    case ("in", json) =>
+      json.asArray flatMap { vec =>
+        // maybe it's a non-empty list of strings
+        (vec traverse { js =>
+          js.asString flatMap { NonEmptyString.from(_).toOption }
+        } flatMap { _.toNev } map { vec =>
+          InStrings(vec.toNonEmptyList)
+        }) orElse
+          // or maybe it's a non-empty list of numbers
+          (vec traverse { js =>
+            js.asNumber map { _.toDouble }
+          } flatMap { _.toNev } map { vec => InNumbers(vec.toNonEmptyList) })
+      }
+    case _ => None
+  }
+}

--- a/application/src/test/scala/com/azavea/franklin/Generators.scala
+++ b/application/src/test/scala/com/azavea/franklin/Generators.scala
@@ -4,6 +4,7 @@ import java.time.Instant
 
 import org.scalacheck.cats.implicits._
 import cats.implicits._
+import com.azavea.franklin.datamodel._
 import com.azavea.franklin.database.SearchFilters
 import org.scalacheck._
 import com.azavea.stac4s._
@@ -69,7 +70,8 @@ trait Generators {
       Gen.const(List.empty[String]),
       Gen.const(List.empty[String]),
       Gen.option(Gen.choose(1, 20)),
-      Gen.const[Option[String]](None)
+      Gen.const[Option[String]](None),
+      Gen.const(Map.empty[String, List[Query]])
     ).mapN(SearchFilters.apply)
   }
 

--- a/application/src/test/scala/com/azavea/franklin/Generators.scala
+++ b/application/src/test/scala/com/azavea/franklin/Generators.scala
@@ -94,7 +94,13 @@ trait Generators {
       (nonEmptyAlphaStringGen, nonEmptyAlphaStringGen).tupled.map({
         case (k, v) => Map(k -> v).asJson
       })
-    ) map In.apply
+    ) map In.apply,
+    nonEmptyVectorGen(arbitrary[Int] map { _.asJson }) map Superset.apply,
+    nonEmptyVectorGen(
+      (nonEmptyAlphaStringGen, nonEmptyAlphaStringGen).tupled.map({
+        case (k, v) => Map(k -> v).asJson
+      })
+    ) map Superset.apply
   )
 
   implicit val arbInstant: Arbitrary[Instant] = Arbitrary { instantGen }

--- a/application/src/test/scala/com/azavea/franklin/api/services/SearchServiceSpec.scala
+++ b/application/src/test/scala/com/azavea/franklin/api/services/SearchServiceSpec.scala
@@ -20,7 +20,7 @@ class SearchServiceSpec
   def is = s2"""
   This specification verifies that the Search Service can run without crashing
 
-  The model service should:
+  The search service should:
     - search with POST search filters         $postSearchFiltersExpectation
     - search with GET search filters          $getSearchFiltersExpectation
 """

--- a/build.sbt
+++ b/build.sbt
@@ -111,6 +111,7 @@ lazy val applicationDependencies = Seq(
   "io.circe"                    %% "circe-numbers"            % Versions.CirceVersion,
   "io.circe"                    %% "circe-parser"             % Versions.CirceVersion,
   "io.circe"                    %% "circe-refined"            % Versions.CirceVersion,
+  "io.circe"                    %% "circe-testing"            % Versions.CirceVersion % "test",
   "net.postgis"                 % "postgis-jdbc"              % Versions.Postgis,
   "net.postgis"                 % "postgis-geometry"          % Versions.Postgis,
   "org.flywaydb"                % "flyway-core"               % Versions.Flyway,

--- a/build.sbt
+++ b/build.sbt
@@ -139,6 +139,7 @@ lazy val applicationDependencies = Seq(
   "org.tpolecat"                %% "doobie-hikari"            % Versions.DoobieVersion,
   "org.tpolecat"                %% "doobie-postgres"          % Versions.DoobieVersion,
   "org.tpolecat"                %% "doobie-postgres-circe"    % Versions.DoobieVersion,
+  "org.tpolecat"                %% "doobie-refined"           % Versions.DoobieVersion,
   "org.tpolecat"                %% "doobie-scalatest"         % Versions.DoobieVersion % "test",
   "org.tpolecat"                %% "doobie-specs2"            % Versions.DoobieVersion % "test",
   "org.typelevel"               %% "cats-core"                % Versions.CatsVersion,


### PR DESCRIPTION
## Overview

This PR adds (will add) support for the [query extension](https://github.com/radiantearth/stac-api-spec/tree/master/extensions/query), which allows querying STAC items by arbitrary fields in their `properties`.

### Checklist

- [x] New tests have been added or existing tests have been modified

### Notes

It's not really clear what should happen with poorly typed queries. If there are two items with incompatible field types (e.g., one has `"foo": 3` and the other has `"foo": "bar"`, I don't think it will be possible to filter on `foo` because postgres will freak out about the invalid comparison for one of them. One option is just to make everything a `String` at filter time I guess, but it feels bad. I'm hopeful that collection filters will prevent this from happening too frequently but it's tough to know that for certain.

~Also the valid types for queries aren't super well-defined. Can I do `"eq": ["some", "array"]`? I don't know! With the preference against nesting I'm assuming that the query extension is primarily for fields that have string or numeric values, but I don't know about arrays.~ It turns out I can dodge this problem entirely with `jsonb` equality checks. It should also fix the inconsistent postgres types issue I think.

### Testing Instructions

- import the berlin data: `bloop run application -- import --catalog-root s3://rasterfoundry-development-data-us-east-1/berlin-catalog/catalog.json --db-host localhost`
- save this json to `filters.json`:

```json
{
    "bbox": null,
    "datetime": null,
    "intersects": null,
    "collections": ["berlin"],
    "query": {
	"datetime": {
	    "eq": "2018-03-03T10:20:19Z"
	}
    }
}
```

- start up the server
- `cat filters.json | http :9090/search` -- you should get the `image` stac item back
- change the `eq` to a `neq` -- you should get no results back
- more exciting: change `datetime` to `label:type` and the datetime string to `"raster"` -- you should get items back with `label:type` equal to `"raster"`

Closes #36 
