### PR TITLE
Upgrade stac4s to 0.0.9

### DIFF
--- a/application/src/main/scala/com/azavea/franklin/api/Server.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/Server.scala
@@ -127,8 +127,8 @@ $$$$
           .use(_ => IO.never)
           .as(ExitCode.Success)
       case RunMigrations(config) => runMigrations(config)
-      case RunImport(catalogRoot, externalPort, apiHost, apiScheme, dbConfig) =>
-        runImport(catalogRoot, externalPort, apiHost, apiScheme, dbConfig) map { _ =>
+      case RunImport(catalogRoot, externalPort, apiHost, apiScheme, dbConfig, dryRun) =>
+        runImport(catalogRoot, externalPort, apiHost, apiScheme, dbConfig, dryRun) map { _ =>
           ExitCode.Success
         }
     } match {

--- a/application/src/main/scala/com/azavea/franklin/api/endpoints/TileEndpoints.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/endpoints/TileEndpoints.scala
@@ -7,6 +7,7 @@ import com.azavea.franklin.datamodel.{
 }
 import com.azavea.franklin.error.NotFound
 import eu.timepit.refined.types.numeric.NonNegInt
+import eu.timepit.refined.types.string.NonEmptyString
 import io.circe.Json
 import sttp.model.StatusCode.{NotFound => NF}
 import sttp.tapir._
@@ -23,6 +24,9 @@ class TileEndpoints(enableTiles: Boolean) {
 
   val collectionFootprintTilePath: EndpointInput[(String, Int, Int, Int)] =
     (basePath / path[String] / "footprint" / "WebMercatorQuad" / zxyPath)
+
+  val collectionFootprintTileParameters: EndpointInput[(String, Int, Int, Int, NonEmptyString)] =
+    collectionFootprintTilePath.and(query[NonEmptyString]("colorField"))
 
   val collectionFootprintTileJsonPath: EndpointInput[String] =
     (basePath / path[String] / "footprint" / "tile-json")
@@ -50,7 +54,7 @@ class TileEndpoints(enableTiles: Boolean) {
   val collectionFootprintTileEndpoint
       : Endpoint[MapboxVectorTileFootprintRequest, NotFound, Array[Byte], Nothing] =
     endpoint.get
-      .in(collectionFootprintTilePath.mapTo(MapboxVectorTileFootprintRequest))
+      .in(collectionFootprintTileParameters.mapTo(MapboxVectorTileFootprintRequest))
       .out(rawBinaryBody[Array[Byte]])
       .out(header("content-type", "application/vnd.mapbox-vector-tile"))
       .errorOut(oneOf(statusMapping(NF, jsonBody[NotFound].description("not found"))))

--- a/application/src/main/scala/com/azavea/franklin/api/implicits/package.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/implicits/package.scala
@@ -31,8 +31,7 @@ package object implicits {
             s"$apiHost/collections/$collectionId/items/$encodedItemId/tiles",
             StacLinkType.VendorLinkType("tiles"),
             Some(`application/json`),
-            Some("Tile URLs for Item"),
-            List.empty
+            Some("Tile URLs for Item")
           )
           tileLink :: item.links
         }
@@ -49,8 +48,7 @@ package object implicits {
         s"$apiHost/collections/${collection.id}/tiles",
         StacLinkType.VendorLinkType("tiles"),
         Some(`application/json`),
-        Some("Tile URLs for Collection"),
-        List.empty
+        Some("Tile URLs for Collection")
       )
       collection.copy(links = tileLink :: collection.links)
     }

--- a/application/src/main/scala/com/azavea/franklin/api/implicits/package.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/implicits/package.scala
@@ -26,9 +26,10 @@ package object implicits {
       }
       val updatedLinks = cogAsset match {
         case true => {
-          val encodedItemId = URLEncoder.encode(itemId, StandardCharsets.UTF_8.toString)
+          val encodedItemId       = URLEncoder.encode(itemId, StandardCharsets.UTF_8.toString)
+          val encodedCollectionId = URLEncoder.encode(collectionId, StandardCharsets.UTF_8.toString)
           val tileLink: StacLink = StacLink(
-            s"$apiHost/collections/$collectionId/items/$encodedItemId/tiles",
+            s"$apiHost/collections/$encodedCollectionId/items/$encodedItemId/tiles",
             StacLinkType.VendorLinkType("tiles"),
             Some(`application/json`),
             Some("Tile URLs for Item")
@@ -44,8 +45,9 @@ package object implicits {
   implicit class StacCollectionWithTiles(collection: StacCollection) {
 
     def addTilesLink(apiHost: String): StacCollection = {
+      val encodedCollectionId = URLEncoder.encode(collection.id, StandardCharsets.UTF_8.toString)
       val tileLink = StacLink(
-        s"$apiHost/collections/${collection.id}/tiles",
+        s"$apiHost/collections/$encodedCollectionId/tiles",
         StacLinkType.VendorLinkType("tiles"),
         Some(`application/json`),
         Some("Tile URLs for Collection")

--- a/application/src/main/scala/com/azavea/franklin/api/services/CollectionItemsService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/CollectionItemsService.scala
@@ -115,8 +115,7 @@ class CollectionItemsService[F[_]: Sync](
       s"$apiHost/collections/$collectionId",
       StacLinkType.Parent,
       Some(`application/json`),
-      Some("Parent collection"),
-      Nil
+      Some("Parent collection")
     )
     item.collection match {
       case Some(collId) =>

--- a/application/src/main/scala/com/azavea/franklin/commands/Commands.scala
+++ b/application/src/main/scala/com/azavea/franklin/commands/Commands.scala
@@ -4,9 +4,11 @@ import cats.effect.{ContextShift, ExitCode, IO}
 import cats.implicits._
 import com.azavea.franklin.crawler.StacImport
 import com.monovore.decline._
-import doobie.util.transactor.Transactor
+import doobie.Transactor
 import eu.timepit.refined.types.numeric.PosInt
 import org.flywaydb.core.Flyway
+import doobie.free.connection.{rollback, setAutoCommit, unit}
+import doobie.util.transactor.Strategy
 
 object Commands {
 
@@ -19,7 +21,8 @@ object Commands {
       externalPort: PosInt,
       apiHost: String,
       apiScheme: String,
-      config: DatabaseConfig
+      config: DatabaseConfig,
+      dryRun: Boolean
   )
 
   private def runImportOpts(implicit cs: ContextShift[IO]): Opts[RunImport] =
@@ -29,7 +32,8 @@ object Commands {
         Options.externalPort,
         Options.apiHost,
         Options.apiScheme,
-        Options.databaseConfig
+        Options.databaseConfig,
+        Options.dryRun
       ).mapN(RunImport)
     }
 
@@ -62,13 +66,25 @@ object Commands {
       externalPort: PosInt,
       apiHost: String,
       apiScheme: String,
-      config: DatabaseConfig
+      config: DatabaseConfig,
+      dryRun: Boolean
   )(
       implicit contextShift: ContextShift[IO]
   ): IO[Unit] = {
     val serverHost = getHost(externalPort, apiHost, apiScheme)
     val xa =
-      Transactor.fromDriverManager[IO](config.driver, config.jdbcUrl, config.dbUser, config.dbPass)
+      Transactor.strategy.set(
+        Transactor.fromDriverManager[IO](
+          config.driver,
+          config.jdbcUrl,
+          config.dbUser,
+          config.dbPass
+        ),
+        if (dryRun) {
+          Strategy.default.copy(before = setAutoCommit(false), after = rollback, always = unit)
+        } else { Strategy.default }
+      )
+
     new StacImport(stacCatalog, serverHost).runIO(xa)
   }
 

--- a/application/src/main/scala/com/azavea/franklin/commands/Commands.scala
+++ b/application/src/main/scala/com/azavea/franklin/commands/Commands.scala
@@ -5,10 +5,10 @@ import cats.implicits._
 import com.azavea.franklin.crawler.StacImport
 import com.monovore.decline._
 import doobie.Transactor
-import eu.timepit.refined.types.numeric.PosInt
-import org.flywaydb.core.Flyway
 import doobie.free.connection.{rollback, setAutoCommit, unit}
 import doobie.util.transactor.Strategy
+import eu.timepit.refined.types.numeric.PosInt
+import org.flywaydb.core.Flyway
 
 object Commands {
 

--- a/application/src/main/scala/com/azavea/franklin/commands/Options.scala
+++ b/application/src/main/scala/com/azavea/franklin/commands/Options.scala
@@ -6,4 +6,7 @@ object Options extends DatabaseOptions with ApiOptions {
 
   val catalogRoot: Opts[String] = Opts
     .option[String]("catalog-root", "Root of STAC catalog to import")
+
+  val dryRun: Opts[Boolean] =
+    Opts.flag("dry-run", help = "Walk a catalog, but don't commit records to the database").orFalse
 }

--- a/application/src/main/scala/com/azavea/franklin/crawler/CollectionWrapper.scala
+++ b/application/src/main/scala/com/azavea/franklin/crawler/CollectionWrapper.scala
@@ -26,16 +26,14 @@ case class CollectionWrapper(
       s"${serverHost.value}/collections/$encodedCollectionId/items/$encodedItemId",
       StacLinkType.Self,
       Some(`application/geo+json`),
-      Some(item.id),
-      List.empty
+      Some(item.id)
     )
 
     val parentLink = StacLink(
       s"${serverHost.value}/collections/$encodedCollectionId/",
       StacLinkType.Parent,
       Some(`application/json`),
-      collection.title,
-      List.empty
+      collection.title
     )
 
     val collectionLink = parentLink.copy(rel = StacLinkType.Collection)
@@ -53,8 +51,7 @@ case class CollectionWrapper(
       s"${serverHost.value}/",
       StacLinkType.StacRoot,
       None,
-      None,
-      List.empty
+      None
     )
 
     val collectionId = URLEncoder.encode(value.id, StandardCharsets.UTF_8.toString)
@@ -66,8 +63,7 @@ case class CollectionWrapper(
         s"${serverHost.value}/collections/$collectionId/items/$itemId",
         StacLinkType.Item,
         Some(`application/geo+json`),
-        Some(item.id),
-        List.empty
+        Some(item.id)
       )
     }
 
@@ -77,8 +73,7 @@ case class CollectionWrapper(
         s"${serverHost.value}/collections/$encodedChildId/",
         StacLinkType.Child,
         Some(`application/json`),
-        child.value.title,
-        List.empty
+        child.value.title
       )
     }
 
@@ -89,8 +84,7 @@ case class CollectionWrapper(
           s"${serverHost.value}/collections/$encodedParentId/",
           StacLinkType.Parent,
           Some(`application/json`),
-          p.value.title,
-          List.empty
+          p.value.title
         )
       )
     }
@@ -99,8 +93,7 @@ case class CollectionWrapper(
       s"${serverHost.value}/collections/$collectionId/",
       StacLinkType.Self,
       Some(`application/json`),
-      value.title,
-      List.empty
+      value.title
     )
     val updatedLinks =
       selfLink :: rootLink :: filterLinks(value.links) ++ childrenLinks ++ itemLinks ++ parentLink

--- a/application/src/main/scala/com/azavea/franklin/crawler/FeatureExtractor.scala
+++ b/application/src/main/scala/com/azavea/franklin/crawler/FeatureExtractor.scala
@@ -32,16 +32,14 @@ object FeatureExtractor {
       collectionHref,
       StacLinkType.Collection,
       Some(`application/json`),
-      title = Some("Source item's original collection"),
-      Nil
+      title = Some("Source item's original collection")
     )
 
     val sourceItemLink = StacLink(
       sourceItemHref,
       StacLinkType.VendorLinkType("derived_from"),
       Some(`application/json`),
-      None,
-      Nil
+      None
     )
 
     val featureExtent = feature.geom.extent

--- a/application/src/main/scala/com/azavea/franklin/crawler/StacImport.scala
+++ b/application/src/main/scala/com/azavea/franklin/crawler/StacImport.scala
@@ -17,6 +17,7 @@ import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import io.circe.Decoder
 import io.circe.JsonObject
 import io.circe.parser.decode
+import io.circe.syntax._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -129,16 +130,14 @@ class StacImport(val catalogRoot: String, serverHost: NonEmptyString) {
               parentCollectionHref,
               StacLinkType.Collection,
               Some(`application/json`),
-              None,
-              Nil
+              None
             )
             val derivedFromItemLink =
               StacLink(
                 derivedFromItemHref,
                 StacLinkType.VendorLinkType("derived_from"),
                 Some(`application/json`),
-                None,
-                Nil
+                None
               )
             val labelCollection = StacCollection(
               "0.9.0",
@@ -150,6 +149,7 @@ class StacImport(val catalogRoot: String, serverHost: NonEmptyString) {
               Proprietary(),
               Nil,
               inCollection.extent.copy(spatial = SpatialExtent(List(forItem.bbox))),
+              ().asJsonObject,
               forItem.properties,
               List(parentCollectionLink, derivedFromItemLink)
             )
@@ -170,7 +170,7 @@ class StacImport(val catalogRoot: String, serverHost: NonEmptyString) {
                   .encode(labelCollection.id, StandardCharsets.UTF_8.toString)}",
                 None,
                 Some("Collection containing items for this item's label geojson asset"),
-                List(StacAssetRole.Data),
+                Set(StacAssetRole.Data),
                 Some(`application/json`)
               )
             )

--- a/application/src/main/scala/com/azavea/franklin/crawler/StacImport.scala
+++ b/application/src/main/scala/com/azavea/franklin/crawler/StacImport.scala
@@ -6,6 +6,8 @@ import com.amazonaws.services.s3.{AmazonS3ClientBuilder, AmazonS3URI}
 import com.azavea.franklin.database.{StacCollectionDao, StacItemDao}
 import com.azavea.stac4s.StacLinkType._
 import com.azavea.stac4s._
+import com.azavea.stac4s.extensions.label.LabelItemExtension
+import com.azavea.stac4s.syntax._
 import doobie.ConnectionIO
 import doobie.implicits._
 import doobie.util.transactor.Transactor
@@ -118,6 +120,10 @@ class StacImport(val catalogRoot: String, serverHost: NonEmptyString) {
     val geojsonAssets = forItem.assets.toList.filter {
       case (_, asset) => asset._type === Some(`application/geo+json`)
     }
+    println(
+      s"Extension decode result for path $fromPath:\n${forItem.getExtensionFields[LabelItemExtension]}"
+    )
+    println(s"GeoJSON assets are:\n${geojsonAssets}")
     geojsonAssets.zipWithIndex traverse {
       case ((assetKey, asset), idx) =>
         readPath[JsonFeatureCollection](makeAbsPath(fromPath, asset.href)) map {
@@ -170,7 +176,7 @@ class StacImport(val catalogRoot: String, serverHost: NonEmptyString) {
                   .encode(labelCollection.id, StandardCharsets.UTF_8.toString)}",
                 None,
                 Some("Collection containing items for this item's label geojson asset"),
-                Set(StacAssetRole.Data),
+                Set(StacAssetRole.VendorAsset("data-collection")),
                 Some(`application/json`)
               )
             )

--- a/application/src/main/scala/com/azavea/franklin/database/StacCollectionDao.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/StacCollectionDao.scala
@@ -47,7 +47,7 @@ object StacCollectionDao {
             ST_Transform(geom, 3857),
             ST_TileEnvelope(${request.z},${request.x},${request.y})
           ) AS geom,
-          item -> 'properties'
+          item -> 'properties' ->> 'class' as class
         FROM collection_items
         WHERE
           ST_Intersects(

--- a/application/src/main/scala/com/azavea/franklin/database/StacCollectionDao.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/StacCollectionDao.scala
@@ -5,6 +5,7 @@ import com.azavea.stac4s._
 import doobie._
 import doobie.free.connection.ConnectionIO
 import doobie.implicits._
+import doobie.refined.implicits._
 
 object StacCollectionDao {
 
@@ -47,7 +48,8 @@ object StacCollectionDao {
             ST_Transform(geom, 3857),
             ST_TileEnvelope(${request.z},${request.x},${request.y})
           ) AS geom,
-          item -> 'properties' ->> 'class' as class
+          item -> 'properties' ->> ${request.colorField} as color,
+          item -> 'properties' as item_properties
         FROM collection_items
         WHERE
           ST_Intersects(

--- a/application/src/main/scala/com/azavea/franklin/datamodel/TileRequest.scala
+++ b/application/src/main/scala/com/azavea/franklin/datamodel/TileRequest.scala
@@ -1,6 +1,7 @@
 package com.azavea.franklin.datamodel
 
 import eu.timepit.refined.types.numeric.NonNegInt
+import eu.timepit.refined.types.string.NonEmptyString
 
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
@@ -51,7 +52,8 @@ case class MapboxVectorTileFootprintRequest(
     collectionRaw: String,
     z: Int,
     x: Int,
-    y: Int
+    y: Int,
+    colorField: NonEmptyString
 ) extends TileMatrixRequest {
   val collection = urlDecode(collectionRaw)
 }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -32,7 +32,7 @@ object Versions {
   val SourceCodeVersion       = "0.2.1"
   val Specs2Version           = "4.9.4"
   val SpireVersion            = "0.13.0"
-  val Stac4SVersion           = "0.0.8"
+  val Stac4SVersion           = "0.0.9"
   val SttpModelVersion        = "1.1.3"
   val TapirVersion            = "0.15.3"
 }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -32,7 +32,7 @@ object Versions {
   val SourceCodeVersion       = "0.2.1"
   val Specs2Version           = "4.9.4"
   val SpireVersion            = "0.13.0"
-  val Stac4SVersion           = "f2ccdf6-SNAPSHOT"
+  val Stac4SVersion           = "0.0.8"
   val SttpModelVersion        = "1.1.3"
   val TapirVersion            = "0.15.3"
 }


### PR DESCRIPTION
## Overview

This PR upgrades stac4s to 0.0.9, which solves some strange json encoding issues with `VendorFoo` types for the different enum values. It also fixes a URL encoding issue in tiles links.

It will grow to include other changes in service of raster-foundry/stac-viewer#19. Those other changes include:

- adding required `colorField` query param to the mvt footprint endpoint (since it's what we use for the data collection)
- using that field to pull out a specific value from the item properties in the footprint endpoint db interaction so that the `color` can be in a consistent place
- adding a `data-colelction` role to the geojson collection we create for label items

Clients should provide the `colorField` value by using the `label:color` attribute on label items (proposed in radiant-earth/stac-spec#842).

### Checklist

- ~New tests have been added or existing tests have been modified~

### Notes

This required editing the item with the predictions so that it became a valid label item. You'll need to re-import the data unless  you've imported after 4:00 PM EST 6/8/2020. Also because I edited the data for the new label item field.

### Testing Instructions

- `./scripts/dbshell`, then `truncate table collections; truncate table collection_items;`
- import the example catalog again -- `env AWS_PROFILE=raster-foundry AWS_REGION=us-east-1 bloop run application -- import --catalog-root s3://rasterfoundry-development-data-us-east-1/berlin-catalog/catalog.json --db-host localhost`
- import should succeed and you should have collections in your db
- start the server with tiles -- `./scripts/server --with-tiles`
- check the tiles links of the second returned collection -- it should be clickable and not have spaces in it
- then point your STAC viewer based on https://github.com/raster-foundry/stac-viewer/pull/24 at this and do what the GIF does in that PR