### PR TITLE
Make collections postable

### DIFF
--- a/application/src/main/scala/com/azavea/franklin/api/Server.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/Server.scala
@@ -80,6 +80,7 @@ $$$$
         apiConfig.enableTiles
       )
       collectionEndpoints = new CollectionEndpoints(
+        apiConfig.enableTransactions,
         apiConfig.enableTiles
       )
       allEndpoints = LandingPageEndpoints.endpoints ++ collectionEndpoints.endpoints ++ collectionItemEndpoints.endpoints ++ SearchEndpoints.endpoints ++ new TileEndpoints(
@@ -90,7 +91,12 @@ $$$$
       landingPageRoutes = new LandingPageService[IO](apiConfig).routes
       searchRoutes      = new SearchService[IO](apiConfig.apiHost, apiConfig.enableTiles, xa).routes
       tileRoutes        = new TileService[IO](apiConfig.apiHost, apiConfig.enableTiles, xa).routes
-      collectionRoutes = new CollectionsService[IO](xa, apiConfig.apiHost, apiConfig.enableTiles).routes <+> new CollectionItemsService[
+      collectionRoutes = new CollectionsService[IO](
+        xa,
+        apiConfig.apiHost,
+        apiConfig.enableTransactions,
+        apiConfig.enableTiles
+      ).routes <+> new CollectionItemsService[
         IO
       ](
         xa,


### PR DESCRIPTION
## Overview

This PR adds an endpoint to POST collections. It removes all of the posted collection's item, root, and self links and replaces the root and self with references in the API. It doesn't make any decisions about what should happen with `child` links. I have really no idea what should happen with child links :thinking:.

### Checklist

- [ ] New tests have been added or existing tests have been modified -- leaving this unchecked, since we don't currently have a `CollectionServiceSpec` (or any specs that test things where items get created) but we _do_ have an issue to add such tests. I think we should defer to that since it's already planned.

### Notes

soft blocked (voluntarily) by #249 which upgrades stac4s and removes a parameter from `StacLink.apply`

### Testing Instructions

- grab this nice [simple example collection](https://github.com/radiantearth/stac-spec/blob/label/js/add-color-field/extensions/label/examples/catalog-with-label-color-field/collection.json) and put it in `collection.json`
- `./sbt bloopInstall` if you haven't in a while
- `AWS_PROFILE=raster-foundry ./scripts/server --with-transactions`
- `cat collection.json | http :9090/collections`
- it should work

Closes #235 