### PR TITLE
Rewrite links on requests and not on import

### DIFF
--- a/application/src/main/scala/com/azavea/franklin/api/Server.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/Server.scala
@@ -98,17 +98,12 @@ $$$$
       tileRoutes = new TileService[IO](apiConfig.apiHost, apiConfig.enableTiles, xa).routes
       collectionRoutes = new CollectionsService[IO](
         xa,
-        apiConfig.apiHost,
-        apiConfig.enableTransactions,
-        apiConfig.enableTiles
+        apiConfig
       ).routes <+> new CollectionItemsService[
         IO
       ](
         xa,
-        apiConfig.apiHost,
-        apiConfig.defaultLimit,
-        apiConfig.enableTransactions,
-        apiConfig.enableTiles
+        apiConfig
       ).routes
       router = CORS(
         Router(
@@ -139,10 +134,8 @@ $$$$
           .use(_ => IO.never)
           .as(ExitCode.Success)
       case RunMigrations(config) => runMigrations(config)
-      case RunImport(catalogRoot, externalPort, apiHost, apiScheme, dbConfig, dryRun) =>
-        runImport(catalogRoot, externalPort, apiHost, apiScheme, dbConfig, dryRun) map { _ =>
-          ExitCode.Success
-        }
+      case RunImport(catalogRoot, dbConfig, dryRun) =>
+        runImport(catalogRoot, dbConfig, dryRun) map { _ => ExitCode.Success }
     } match {
       case Left(e) =>
         IO {

--- a/application/src/main/scala/com/azavea/franklin/api/implicits/package.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/implicits/package.scala
@@ -1,5 +1,6 @@
 package com.azavea.franklin.api
 
+import com.azavea.franklin.api.commands.ApiConfig
 import com.azavea.stac4s._
 import eu.timepit.refined.types.string.NonEmptyString
 
@@ -16,6 +17,11 @@ package object implicits {
   }
 
   implicit class StacItemWithCog(item: StacItem) {
+
+    def updateLinksWithHost(apiConfig: ApiConfig) = {
+      val updatedLinks = item.links.map(_.addServerHost(apiConfig))
+      item.copy(links = updatedLinks)
+    }
 
     def addTilesLink(apiHost: String, collectionId: String, itemId: String) = {
       val cogAsset = item.assets.values.exists { asset =>
@@ -40,6 +46,17 @@ package object implicits {
       }
       (item.copy(links = updatedLinks))
     }
+
+  }
+
+  implicit class UpdatedStacLink(link: StacLink) {
+
+    def addServerHost(apiConfig: ApiConfig) = {
+      link.href.startsWith("/") match {
+        case true => link.copy(href = s"${apiConfig.apiHost}${link.href}")
+        case _    => link
+      }
+    }
   }
 
   implicit class StacCollectionWithTiles(collection: StacCollection) {
@@ -57,6 +74,10 @@ package object implicits {
 
     def maybeAddTilesLink(enableTiles: Boolean, apiHost: String) =
       if (enableTiles) addTilesLink(apiHost) else collection
-  }
 
+    def updateLinksWithHost(apiConfig: ApiConfig) = {
+      val updatedLinks = collection.links.map(_.addServerHost(apiConfig))
+      collection.copy(links = updatedLinks)
+    }
+  }
 }

--- a/application/src/main/scala/com/azavea/franklin/crawler/CollectionWrapper.scala
+++ b/application/src/main/scala/com/azavea/franklin/crawler/CollectionWrapper.scala
@@ -1,7 +1,6 @@
 package com.azavea.franklin.crawler
 
 import com.azavea.stac4s._
-import eu.timepit.refined.types.string.NonEmptyString
 
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
@@ -17,20 +16,19 @@ case class CollectionWrapper(
   private def updateItemLinks(
       collection: StacCollection,
       item: StacItem,
-      serverHost: NonEmptyString,
       rootLink: StacLink
   ) = {
     val encodedItemId       = URLEncoder.encode(item.id, StandardCharsets.UTF_8.toString)
     val encodedCollectionId = URLEncoder.encode(collection.id, StandardCharsets.UTF_8.toString)
     val selfLink = StacLink(
-      s"${serverHost.value}/collections/$encodedCollectionId/items/$encodedItemId",
+      s"/collections/$encodedCollectionId/items/$encodedItemId",
       StacLinkType.Self,
       Some(`application/geo+json`),
       Some(item.id)
     )
 
     val parentLink = StacLink(
-      s"${serverHost.value}/collections/$encodedCollectionId/",
+      s"/collections/$encodedCollectionId/",
       StacLinkType.Parent,
       Some(`application/json`),
       collection.title
@@ -45,10 +43,10 @@ case class CollectionWrapper(
   }
 
   // Updates links for collection and its children + items
-  def updateLinks(serverHost: NonEmptyString): CollectionWrapper = {
+  def updateLinks: CollectionWrapper = {
 
     val rootLink = StacLink(
-      s"${serverHost.value}/",
+      "/",
       StacLinkType.StacRoot,
       None,
       None
@@ -60,7 +58,7 @@ case class CollectionWrapper(
       val itemId = URLEncoder.encode(item.id, StandardCharsets.UTF_8.toString)
 
       StacLink(
-        s"${serverHost.value}/collections/$collectionId/items/$itemId",
+        s"/collections/$collectionId/items/$itemId",
         StacLinkType.Item,
         Some(`application/geo+json`),
         Some(item.id)
@@ -70,7 +68,7 @@ case class CollectionWrapper(
     val childrenLinks = children.map { child =>
       val encodedChildId = URLEncoder.encode(child.value.id, StandardCharsets.UTF_8.toString)
       StacLink(
-        s"${serverHost.value}/collections/$encodedChildId/",
+        s"/collections/$encodedChildId/",
         StacLinkType.Child,
         Some(`application/json`),
         child.value.title
@@ -81,7 +79,7 @@ case class CollectionWrapper(
       val encodedParentId = URLEncoder.encode(p.value.id, StandardCharsets.UTF_8.toString)
       List(
         StacLink(
-          s"${serverHost.value}/collections/$encodedParentId/",
+          s"/collections/$encodedParentId/",
           StacLinkType.Parent,
           Some(`application/json`),
           p.value.title
@@ -90,7 +88,7 @@ case class CollectionWrapper(
     }
 
     val selfLink = StacLink(
-      s"${serverHost.value}/collections/$collectionId/",
+      s"/collections/$collectionId/",
       StacLinkType.Self,
       Some(`application/json`),
       value.title
@@ -104,8 +102,8 @@ case class CollectionWrapper(
     CollectionWrapper(
       value.copy(links = updatedLinks),
       parent,
-      children.map(_.updateLinks(serverHost)),
-      items.map(i => updateItemLinks(value, i, serverHost, rootLink))
+      children.map(_.updateLinks),
+      items.map(i => updateItemLinks(value, i, rootLink))
     )
   }
 }

--- a/application/src/main/scala/com/azavea/franklin/crawler/FeatureExtractor.scala
+++ b/application/src/main/scala/com/azavea/franklin/crawler/FeatureExtractor.scala
@@ -3,7 +3,6 @@ package com.azavea.franklin.crawler
 import com.azavea.stac4s.StacLink
 import com.azavea.stac4s.TwoDimBbox
 import com.azavea.stac4s._
-import eu.timepit.refined.types.string.NonEmptyString
 import geotrellis.vector.methods.Implicits._
 import geotrellis.vector.{Feature, Geometry}
 import io.circe.JsonObject
@@ -18,15 +17,14 @@ object FeatureExtractor {
       feature: Feature[Geometry, JsonObject],
       forItem: StacItem,
       forItemCollection: String,
-      inCollection: StacCollection,
-      serverHost: NonEmptyString
+      inCollection: StacCollection
   ): StacItem = {
     val collectionHref =
-      s"$serverHost/collections/${URLEncoder.encode(inCollection.id, StandardCharsets.UTF_8.toString)}"
+      s"/collections/${URLEncoder.encode(inCollection.id, StandardCharsets.UTF_8.toString)}"
     val encodedSourceItemCollectionId =
       URLEncoder.encode(forItemCollection, StandardCharsets.UTF_8.toString)
     val sourceItemHref =
-      s"$serverHost/collections/$encodedSourceItemCollectionId/items/${URLEncoder.encode(forItem.id, StandardCharsets.UTF_8.toString)}"
+      s"/collections/$encodedSourceItemCollectionId/items/${URLEncoder.encode(forItem.id, StandardCharsets.UTF_8.toString)}"
 
     val collectionLink = StacLink(
       collectionHref,


### PR DESCRIPTION
## Overview

This changes how the server and import process works slightly. Before
this commit item and collection URLs were rewritten when running the
`import` command. After this commit stac link URLs are rewritten per
request for collections and items. This improves portability and
prevents having to reimport data due to server changes or import
errors.

### Checklist

- [ ] New tests have been added or existing tests have been modified

### Testing Instructions

- Import the test berlin catalog - `bloop run application -- import --catalog-root s3://rasterfoundry-development-data-us-east-1/berlin-catalog/catalog.json --db-host=localhost`
- Start server and check the links -- see that they all say `localhost:9090`
- Start the server with an option: `./scripts/server --api-host test.com` and verify that the links for items and collections are updated

Closes #258 