### PR TITLE
Rewrite asset hrefs when necessary

### DIFF
--- a/application/src/main/scala/com/azavea/franklin/api/implicits/package.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/implicits/package.scala
@@ -20,7 +20,13 @@ package object implicits {
 
     def updateLinksWithHost(apiConfig: ApiConfig) = {
       val updatedLinks = item.links.map(_.addServerHost(apiConfig))
-      item.copy(links = updatedLinks)
+      val updatedAssets = item.assets.mapValues { asset =>
+        asset.href.startsWith("/") match {
+          case true => asset.copy(href = s"${apiConfig.apiHost}${asset.href}")
+          case _    => asset
+        }
+      }
+      item.copy(links = updatedLinks, assets = updatedAssets)
     }
 
     def addTilesLink(apiHost: String, collectionId: String, itemId: String) = {


### PR DESCRIPTION
## Overview

Fixes a bug revealed in testing another application that was introduced in #278.

While the API added host information for STAC links, it did not for URLs in STAC assets -- in this case that caused an issue when the labels themselves were imported as a collection.

![image](https://user-images.githubusercontent.com/898060/85598210-5aadd200-b619-11ea-9945-fab45850947a.png)

### Checklist

- [ ] New tests have been added or existing tests have been modified

### Testing Instructions

- Verify that STAC assets are rewritten (this happens when you import a label dataset that has geojson attached)

