### PR TITLE
Add api-path parameter to server startup

### DIFF
--- a/application/src/main/scala/com/azavea/franklin/commands/ApiConfig.scala
+++ b/application/src/main/scala/com/azavea/franklin/commands/ApiConfig.scala
@@ -7,12 +7,16 @@ case class ApiConfig(
     publicPort: PosInt,
     internalPort: PosInt,
     host: String,
+    path: Option[String],
     scheme: String,
     defaultLimit: NonNegInt,
     enableTransactions: Boolean,
     enableTiles: Boolean
 ) {
 
-  val apiHost: NonEmptyString = getHost(publicPort, host, scheme)
+  val apiHost: NonEmptyString =
+    getHost(publicPort, host, scheme, path map { s =>
+      s"/${s.stripPrefix("/").stripSuffix("/")}"
+    } getOrElse "")
 
 }

--- a/application/src/main/scala/com/azavea/franklin/commands/ApiOptions.scala
+++ b/application/src/main/scala/com/azavea/franklin/commands/ApiOptions.scala
@@ -24,6 +24,13 @@ trait ApiOptions {
     .option[String]("api-host", help = "Hostname Franklin is hosted it (e.g. localhost)")
     .withDefault("localhost")
 
+  val apiPath = Opts
+    .option[String](
+      "api-path",
+      help = "Path component for root of Franklin instance (e.g. /stac/api)"
+    )
+    .orNone
+
   val apiScheme =
     Opts
       .option[String]("api-scheme", "Scheme server is exposed to end users with")
@@ -49,6 +56,7 @@ trait ApiOptions {
     externalPort,
     internalPort,
     apiHost,
+    apiPath,
     apiScheme,
     defaultLimit,
     enableTransactions,

--- a/application/src/main/scala/com/azavea/franklin/commands/package.scala
+++ b/application/src/main/scala/com/azavea/franklin/commands/package.scala
@@ -5,11 +5,11 @@ import eu.timepit.refined.types.string.NonEmptyString
 
 package object commands {
 
-  def getHost(port: PosInt, host: String, scheme: String) = {
+  def getHost(port: PosInt, host: String, scheme: String, path: String): NonEmptyString = {
     (port.value, scheme) match {
-      case (443, "https") => NonEmptyString.unsafeFrom(s"$scheme://$host")
-      case (80, "http")   => NonEmptyString.unsafeFrom(s"$scheme://$host")
-      case _              => NonEmptyString.unsafeFrom(s"$scheme://$host:$port")
+      case (443, "https") => NonEmptyString.unsafeFrom(s"$scheme://$host$path")
+      case (80, "http")   => NonEmptyString.unsafeFrom(s"$scheme://$host$path")
+      case _              => NonEmptyString.unsafeFrom(s"$scheme://$host:$port$path")
     }
   }
 

--- a/application/src/test/scala/com/azavea/franklin/api/TestServices.scala
+++ b/application/src/test/scala/com/azavea/franklin/api/TestServices.scala
@@ -9,7 +9,7 @@ import eu.timepit.refined.types.numeric.{NonNegInt, PosInt}
 class TestServices[F[_]: Sync](xa: Transactor[F])(implicit cs: ContextShift[F]) {
 
   val apiConfig: ApiConfig =
-    ApiConfig(PosInt(9090), PosInt(9090), "localhost", "http", NonNegInt(30), true, false)
+    ApiConfig(PosInt(9090), PosInt(9090), "localhost", None, "http", NonNegInt(30), true, false)
 
   val searchService: SearchService[F] =
     new SearchService[F](apiConfig.apiHost, NonNegInt(30), apiConfig.enableTiles, xa)


### PR DESCRIPTION
## Overview

This PR adds an `api-path` server startup. This allows specifying something between `<scheme>://<host>:<port>/` and the API routes.

### Checklist

- ~New tests have been added or existing tests have been modified~

### Notes

I chose this strategy over modifying how we rewrite links because:

- the surface area of the change is really small. There's a new parameter, and `getHost` was updated to respect it. This makes the change easy to review.
- I wasn't sure how to respect non-standard ports if we did this with link rewriting. I didn't want to mess with inserting a port in a link if it was needed, since `foo.com/stac-api:1234` is not a valid address.

### Testing Instructions

- import the sample catalog if you haven't done so in a while (we could maybe use a `load-development-data` command :thinking:)
- `./scripts/server --with-tiles`
- browse the api using the available links -- nothing should be broken by surprise
- kill the server, then restart it with `--api-host foo.com --api-path /api/wow/nice/api/path/params/my/dude/`
- click the link from the landing page -- they should respect the very silly API path that you specified
- try different host + external port parameters, restart your server, and ensure that the links on the landing page and other API endpoints look like you expect them to

Closes #322 