### PR TITLE
Feature/cmb/remove item extent

### DIFF
--- a/application/src/main/resources/migrations/V6__remove_item_extent.sql
+++ b/application/src/main/resources/migrations/V6__remove_item_extent.sql
@@ -1,0 +1,1 @@
+ALTER TABLE collection_items DROP COLUMN extent;

--- a/application/src/main/scala/com/azavea/franklin/database/StacItemDao.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/StacItemDao.scala
@@ -141,11 +141,9 @@ object StacItemDao extends Dao[StacItem] {
       .selectOption
 
   private def doUpdate(itemId: String, item: StacItem): ConnectionIO[StacItem] = {
-    val itemExtent = Projected(item.geometry.getEnvelope, 4326)
     val fragment   = fr"""
       UPDATE collection_items
       SET
-        extent = $itemExtent,
         item = $item
       WHERE id = $itemId
     """

--- a/application/src/main/scala/com/azavea/franklin/database/StacItemDao.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/StacItemDao.scala
@@ -141,7 +141,7 @@ object StacItemDao extends Dao[StacItem] {
       .selectOption
 
   private def doUpdate(itemId: String, item: StacItem): ConnectionIO[StacItem] = {
-    val fragment   = fr"""
+    val fragment = fr"""
       UPDATE collection_items
       SET
         item = $item

--- a/application/src/main/scala/com/azavea/franklin/database/StacItemDao.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/StacItemDao.scala
@@ -124,12 +124,11 @@ object StacItemDao extends Dao[StacItem] {
 
   def insertStacItem(item: StacItem): ConnectionIO[StacItem] = {
     val projectedGeometry = Projected(item.geometry, 4326)
-    val itemExtent        = Projected(item.geometry.getEnvelope, 4326)
 
     val insertFragment = fr"""
-      INSERT INTO collection_items (id, extent, geom, item)
+      INSERT INTO collection_items (id, geom, item)
       VALUES
-      (${item.id}, $itemExtent, $projectedGeometry, $item)
+      (${item.id}, $projectedGeometry, $item)
       """
     insertFragment.update
       .withUniqueGeneratedKeys[StacItem]("item")


### PR DESCRIPTION
## Overview

This removes the `extent` column from collection items in the database. This field was not used in the application and introduced an opportunity for errors because in some cases the import process created extents that were not polygons.

### Notes

The other option was to figure out why the extent of a geometry could be something else besides a polygon; however, since it wasn't important I thought this would be easier.
