### PR TITLE
[Paused] Add HTML view for collections list

### DIFF
--- a/application/src/main/scala/com/azavea/franklin/api/Server.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/Server.scala
@@ -78,7 +78,7 @@ $$$$
         apiConfig.enableTransactions,
         apiConfig.enableTiles
       )
-      collectionEndpoints = new CollectionEndpoints(
+      collectionEndpoints = new CollectionEndpoints[IO](
         apiConfig.enableTransactions,
         apiConfig.enableTiles
       )

--- a/application/src/main/scala/com/azavea/franklin/api/endpoints/CollectionEndpoints.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/endpoints/CollectionEndpoints.scala
@@ -1,14 +1,14 @@
 package com.azavea.franklin.api.endpoints
 
 import cats.effect._
+import com.azavea.franklin.datamodel.CollectionsResponse
 import com.azavea.franklin.error.NotFound
 import com.azavea.stac4s.StacCollection
+import fs2.{Stream => FS2Stream}
 import io.circe._
 import sttp.model.StatusCode.{NotFound => NF}
 import sttp.tapir._
 import sttp.tapir.json.circe._
-import com.azavea.franklin.datamodel.CollectionsResponse
-import fs2.{Stream => FS2Stream}
 
 class CollectionEndpoints[F[_]: Sync](enableTransactions: Boolean, enableTiles: Boolean) {
 

--- a/application/src/main/scala/com/azavea/franklin/api/services/CollectionsService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/CollectionsService.scala
@@ -4,6 +4,7 @@ import cats.effect._
 import cats.implicits._
 import com.azavea.franklin
 import com.azavea.franklin.api.commands.ApiConfig
+import com.azavea.franklin.api.endpoints.AcceptHeader
 import com.azavea.franklin.api.endpoints._
 import com.azavea.franklin.api.implicits._
 import com.azavea.franklin.database.StacCollectionDao
@@ -21,7 +22,6 @@ import sttp.tapir.server.http4s._
 
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
-import com.azavea.franklin.api.endpoints.AcceptHeader
 
 class CollectionsService[F[_]: Sync](
     xa: Transactor[F],

--- a/application/src/main/scala/com/azavea/franklin/api/services/package.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/package.scala
@@ -15,14 +15,15 @@ package object services {
   ): Either[Unit, (String, Stream[F, Byte])] = {
     accept.acceptJson match {
       case true => {
+        println("JSON!!!!")
         val bytes = Stream.emits(json.noSpaces.getBytes())
         Right(("application/json", bytes))
       }
       case _ => {
+        println("HTML!!!!")
         val bytes = Stream.emits(html.getBytes())
         Right(("text/html", bytes))
       }
     }
   }
-
 }

--- a/application/src/main/twirl/com/azavea/franklin/collections.scala.html
+++ b/application/src/main/twirl/com/azavea/franklin/collections.scala.html
@@ -1,0 +1,85 @@
+@import _root_.com.azavea.franklin.datamodel._
+@import _root_.com.azavea.franklin.api.implicits._
+@import _root_.geotrellis.vector.io.json.Implicits._
+@import _root_.io.circe.syntax._
+@import com.azavea.stac4s.StacLinkType
+@import com.azavea.stac4s.StacCollection
+@(collectionsResponse: CollectionsResponse, apiHost: String)
+
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Franklin OGC API - Features, Tiles, and STAC Server</title>
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700" rel="stylesheet">
+  <!-- Bulma Version 0.8.x-->
+  <link rel="stylesheet" href="https://unpkg.com/bulma@@0.8.0/css/bulma.min.css" />
+  <link rel="stylesheet" type="text/css" href="/assets/franklin.css">
+  <script src="/assets/main.bundle.js"></script>
+</head>
+
+  <body>
+    <!-- START NAV -->
+    @navbar(apiHost)
+    <!-- END NAV -->
+
+    <div class="container">
+      <div class="columns">
+        @sidebar("collections", apiHost)
+        <div class="column is-9">
+          <section class="section">
+            <div style="height: 300px" id="map" class="map"></div>
+          </section>
+          <div class="columns">
+            <div class="column is-12">
+              <div class="card events-card box">
+                <header class="card-header">
+                  <p class="card-header-title">
+                    Collections
+                  </p>
+                </header>
+                <div class="card-table">
+                  <div class="content">
+                    <table class="table is-fullwidth is-striped">
+                      <tbody>
+                        <tr>
+                          <th>Name</th>
+                          <th>License</th>
+                          <th>Start</th>
+                          <th>End</th>
+                          <th></th>
+                        </tr>
+                        @for(collection <- collectionsResponse.collections) {
+                          <tr data-collection="@collection.id" class="collection-item">
+                            <td>@collection.title.getOrElse(collection.id)</td>
+                            <td>@collection.license.name</td>
+                            <td>@collection.extent.startTime.getOrElse("")</td>
+                            <td>@collection.extent.endTime.getOrElse("")</td>
+                            <td class="level-right"><a class="button is-small is-primary" href="/collections/@collection.id">View</a></td>
+                          </tr>
+                        }
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <script>
+      var map = franklin.createMap();
+      var features = @Html(collectionsResponse.collections.toGeoJson);
+      var extents = @Html(collectionsResponse.collections.extentMap.asJson.noSpaces);
+      franklin.addGeoJson(map, features);
+      var collectionsExtent = @Html(collectionsResponse.collections.extent.asJson.noSpaces);
+      franklin.fitToBounds(map, collectionsExtent);
+      franklin.addEventListener(map, extents);
+    </script>
+  </body>
+</html>

--- a/application/src/main/twirl/com/azavea/franklin/sidebar.scala.html
+++ b/application/src/main/twirl/com/azavea/franklin/sidebar.scala.html
@@ -3,22 +3,22 @@
 <div class="column is-3 ">
   <aside class="menu is-hidden-mobile">
     <ul class="menu-list">
-      <li><a class="@isActive(activeItem, " home")" href=@apiHost>Home</a></li>
+      <li><a class="@isActive(activeItem, "home")" href=@apiHost>Home</a></li>
     </ul>
     <p class="menu-label">
       Data
     </p>
     <ul class="menu-list">
-      <li><a class="@isActive(activeItem, " collections")" href=@(s"$apiHost/collections/")>Collections Listing</a>
+      <li><a class="@isActive(activeItem, "collections")" href=@(s"$apiHost/collections/")>Collections Listing</a>
       </li>
-      <li><a class="@isActive(activeItem, " search")" href=@(s"$apiHost/search/")>STAC Search</a></li>
+      <li><a class="@isActive(activeItem, "search")" href=@(s"$apiHost/search/")>STAC Search</a></li>
     </ul>
     <p class="menu-label">
       Docs and Other
     </p>
     <ul class="menu-list">
-      <li><a class="@isActive(activeItem, " conformance")" href=@(s"$apiHost/conformance/")>Conformance</a></li>
-      <li><a class="@isActive(activeItem, " spec")" href=@(s"$apiHost/open-api/spec.yaml")>API Specification</a></li>
+      <li><a class="@isActive(activeItem, "conformance")" href=@(s"$apiHost/conformance/")>Conformance</a></li>
+      <li><a class="@isActive(activeItem, "spec")" href=@(s"$apiHost/open-api/spec.yaml")>API Specification</a></li>
     </ul>
   </aside>
 </div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "isolatedModules": false,
     "noEmit": true,
     "jsx": "react",
-    "typeRoots": ["src/types", "node_modules/@types"]
+    "typeRoots": ["src/types", "node_modules/@types"],
+    "experimentalDecorators": true
   },
   "include": [
     "src"


### PR DESCRIPTION
## Overview

_Tests for this are going to fail until https://github.com/azavea/stac4s/pull/135 is integrated_

This PR adds an HTML view for listing collections. It also adds validation to the collection creation endpoint so that incoming collections are required to have valid spatial extents (min < max).


### Testing Instructions

- Start up the server and navigate to the frontend -- you should be able to click the collections link in the side bar and get taken to an HTML view of collections
- the map should zoom to the extent of the existing collections
- clicking a collections should zoom to the extent of that collection

Closes #293 
