### PR TITLE
Fix path relativization

### DIFF
--- a/application/src/main/resources/logback.xml
+++ b/application/src/main/resources/logback.xml
@@ -9,7 +9,7 @@
   <logger name="org.http4s.blaze" level="WARN"/>
   <logger name="org.http4s.blaze.channel.nio1" level="WARN"/>
   <logger name="org.http4s" level="INFO"/>
-  <logger name="com.azavea.franklin" level="${FRANKLIN_LOGGING_LEVEL:-WARN}"/>
+  <logger name="com.azavea.franklin" level="${FRANKLIN_LOG_LEVEL:-WARN}"/>
   <root level="WARN">
     <appender-ref ref="STDOUT" />
   </root>

--- a/application/src/main/scala/com/azavea/franklin/crawler/StacIO.scala
+++ b/application/src/main/scala/com/azavea/franklin/crawler/StacIO.scala
@@ -138,7 +138,7 @@ object StacIO {
         })
 
         val sourceLink =
-          (sourceLinkO, sourceItemO, collectionIdO).tupled map {
+          (sourceLinkO, sourceItemO, sourceItemO flatMap { _.collection }).tupled map {
             case (link, sourceItem, collectionId) =>
               val encodedSourceItemId =
                 encodeString(sourceItem.id)

--- a/application/src/main/scala/com/azavea/franklin/crawler/StacIO.scala
+++ b/application/src/main/scala/com/azavea/franklin/crawler/StacIO.scala
@@ -147,19 +147,27 @@ object StacIO {
               link.copy(href = s"/collections/$encodedCollectionId/items/$encodedSourceItemId")
           }
 
-        val collectionLink = collectionIdO map { collectionId =>
+        val collectionAndSelfLink = collectionIdO map { collectionId =>
           val encodedCollectionId =
             encodeString(collectionId)
-          StacLink(
-            s"/collections/${encodedCollectionId}",
-            StacLinkType.Collection,
-            Some(`application/json`),
-            None
+          List(
+            StacLink(
+              s"/collections/${encodedCollectionId}",
+              StacLinkType.Collection,
+              Some(`application/json`),
+              None
+            ),
+            StacLink(
+              s"/collections/${encodedCollectionId}/items/${encodeString(item.id)}",
+              StacLinkType.Self,
+              Some(`application/json`),
+              None
+            )
           )
         }
 
         item.copy(links =
-          sourceLink.toList ++ collectionLink.toList ++ filterLinks(
+          sourceLink.toList ++ (collectionAndSelfLink getOrElse Nil) ++ filterLinks(
             item.links.filter(_.rel != StacLinkType.Source)
           )
         )

--- a/application/src/main/scala/com/azavea/franklin/crawler/StacItemImporter.scala
+++ b/application/src/main/scala/com/azavea/franklin/crawler/StacItemImporter.scala
@@ -28,7 +28,7 @@ class StacItemImporter(val collectionId: String, val itemUris: NonEmptyList[Stri
   private def readItems(
       collection: StacCollection
   ): EitherT[IO, String, NonEmptyList[StacItem]] = {
-    EitherT.right(itemUris.traverse(uri => StacIO.readItem(uri, true, collection)))
+    EitherT.right(itemUris.traverse(uri => StacIO.readItem(uri, true, Some(collection.id))))
   }
 
   def runIO(xa: Transactor[IO]): IO[Either[String, List[StacItem]]] = {

--- a/application/src/main/scala/com/azavea/franklin/database/StacCollectionDao.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/StacCollectionDao.scala
@@ -1,8 +1,7 @@
 package com.azavea.franklin.database
 
-import com.azavea.franklin.datamodel.MapboxVectorTileFootprintRequest
-
 import cats.data.OptionT
+import com.azavea.franklin.datamodel.MapboxVectorTileFootprintRequest
 import com.azavea.stac4s._
 import doobie._
 import doobie.free.connection.ConnectionIO

--- a/application/src/main/scala/com/azavea/franklin/database/StacItemDao.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/StacItemDao.scala
@@ -194,4 +194,5 @@ object StacItemDao extends Dao[StacItem] {
       }
     } yield update)
   }
+
 }


### PR DESCRIPTION
## Overview

This PR reworks how we recurse through a catalog. It uses `StateT` because I now have exactly one idea. But more importantly, because it does a better job handling some of the stateful recursion we want to do. There may have been some costs though. I believe I've restored all the links we care about, but man it was like pulling teeth. Some time in the future we should probably
overhaul the importer and the database code to insert collections bare and add items + links to them, but for now I settled for:

- the sample from the linked issue processes, kind of, but the items don't have `collection` properties, so only kind of
- the berlin data still imports

Also, because now every non-item check goes for `Collection` _or_ `Catalog`, we get farther with the 5p import in the sense that we can actually try to walk it! So that's pretty cool. The bad news is that the new helpful error messages are now a bit confusing, since they look like something went wrong.

### Checklist

- ~New tests have been added or existing tests have been modified~

### Notes

I still think it's a good idea to review and merge this. It gives us more power, it works for the things it already worked on, and it reveals more places where the importer doesn't make a ton of sense.

There was a bit of whack a mole but I think the importer wound up a lot more robust at the end. Sorry for the extremely long testing instructions, but we haven't really had the chance to test against a more robust set of input catalogs before.

Here's a quickly drawn version of the different STAC topologies you'll be testing with:

![stac-topologies](https://user-images.githubusercontent.com/5702984/90907550-5dfed900-e390-11ea-9897-9b92b9762a99.jpg)

### Testing Instructions

- [ ] `./sbt bloopInstall` since deps are constantly being upgraded
- [ ] `docker-compose up -d database`
- [ ] start the server: `AWS_PROFILE=raster-foundry AWS_REGION=us-east-1 ./scripts/server` (don't worry about tiles or transactions)
- [ ] Here's your base command, memorize it! Or just copy it to your clipboard, whatever you want:

`AWS_PROFILE=raster-foundry AWS_REGION=us-east-1 bloop run application -- import-catalog --db-host localhost --catalog-root foo`

- [ ] replace `foo` with the Berlin catalog: `s3://rasterfoundry-development-data-us-east-1/berlin-catalog/catalog.json` and run the command
- [ ] navigate to `http://localhost:9090/collections/berlin` -- you should be able to browse around in ways you expect (though note that links to individual items have been replaced with an `items` link that goes to the collection's items page -- I think that's probably better and will save us for large upcoming catalogs)
- [ ] download the zip in the linked issue that was produced using `sentinel-2-stac-utils` (example.zip attached to the issue)
- [ ] make a `catalog` directory in this repo
- [ ] unzip it into the `catalog` directory
- [ ] replace `foo` with `$(pwd)/catalog/catalog.json` and run the command
- [ ] it should succeed in the sense that it inserts a `Sentinel-2 Scenes` collection and some items, but it won't know how they're connected since they're `item` links from their immediate parent the catalog and they don't have a `collection` field
- [ ] replace `foo` with the root catalog from the Sentinel 5p data: `https://meeo-s5p.s3.amazonaws.com/catalog.json` and run the command
- [ ] it should attempt to walk the catalog including into children of children, though absolutely nothing will go well enough to insert anything
- [ ] create a STAC export in Groundwork (or just use the one I made just now from https://groundwork.azavea.com/app/projects/d48afcfd-bac5-4a46-b4dd-0fd76ba963ef/exports)
- [ ] download it and find the path to the `catalog.json` at the root of it
- [ ] replace `foo` with the absolute path to that `catalog.json`
- [ ] check out the results in Franklin:
  - [ ] navigate to `localhost:9090/collections`
  - [ ] click the `items` link for the `Layers` collection -- there should be nothing there (relatedly, why do we have this?)
  - [ ] click the `items` link for the `"Images Collection"` collection -- there should be an item in there
  - [ ] click the `items` link for the `"Label Collection"` collection -- there should be an item in there, it should have a source link, and the source link should go to a real place

Closes #344  (if applicable)