### PR TITLE
Add environment variable support for API and database configuration options

### DIFF
--- a/application/src/main/scala/com/azavea/franklin/api/Server.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/Server.scala
@@ -127,7 +127,7 @@ $$$$
   override def run(args: List[String]): IO[ExitCode] = {
     import Commands._
 
-    applicationCommand.parse(args) map {
+    applicationCommand.parse(args, env = sys.env) map {
       case RunServer(apiConfig, dbConfig) if !apiConfig.runMigrations =>
         createServer(apiConfig, dbConfig)
           .use(_ => IO.never)

--- a/application/src/main/scala/com/azavea/franklin/commands/ApiOptions.scala
+++ b/application/src/main/scala/com/azavea/franklin/commands/ApiOptions.scala
@@ -1,28 +1,30 @@
 package com.azavea.franklin.api.commands
 
+import cats.data.Validated
 import cats.implicits._
 import com.monovore.decline.Opts
 import com.monovore.decline.refined._
 import eu.timepit.refined.types.numeric.NonNegInt
 import eu.timepit.refined.types.numeric.PosInt
 
+import scala.language.postfixOps
+import scala.util.Try
+
 trait ApiOptions {
 
   private val portDefault      = PosInt(9090)
   private val externalPortHelp = s"Port users/clients hit for requests. Default: '$portDefault'."
 
-  val externalPort = Opts
-    .option[PosInt]("external-port", help = externalPortHelp) orElse
-    Opts.env[PosInt]("API_EXTERNAL_PORT", help = externalPortHelp) withDefault (portDefault)
+  val externalPort = Opts.option[PosInt]("external-port", help = externalPortHelp) orElse Opts
+    .env[PosInt]("API_EXTERNAL_PORT", help = externalPortHelp) withDefault (portDefault)
 
   private val internalPortHelp =
     s"Port server listens on, this will be different from 'external-port' when service is started behind a proxy. Default: '$portDefault'."
 
-  val internalPort = Opts
-    .option[PosInt](
-      "internal-port",
-      help = internalPortHelp
-    ) orElse Opts
+  val internalPort = Opts.option[PosInt](
+    "internal-port",
+    help = internalPortHelp
+  ) orElse Opts
     .env[PosInt]("API_INTERNAL_PORT", help = internalPortHelp) withDefault (portDefault)
 
   private val apiHostDefault = "localhost"
@@ -30,61 +32,69 @@ trait ApiOptions {
   private val apiHostHelp =
     s"Hostname Franklin is hosted it (e.g. localhost). Default: '$apiHostDefault'."
 
-  val apiHost = Opts
-    .option[String]("api-host", help = apiHostHelp) orElse
-    Opts.env[String]("API_HOST", help = apiHostHelp) withDefault (apiHostDefault)
+  val apiHost = Opts.option[String]("api-host", help = apiHostHelp) orElse Opts
+    .env[String]("API_HOST", help = apiHostHelp) withDefault (apiHostDefault)
 
   private val apiPathHelp = "Path component for root of Franklin instance (e.g. /stac/api)."
 
-  val apiPath = Opts
-    .option[String](
-      "api-path",
-      help = apiPathHelp
-    ) orElse
-    Opts.env[String]("API_PATH", help = apiPathHelp) orNone
+  val apiPath = (Opts.option[String](
+    "api-path",
+    help = apiPathHelp
+  ) orElse Opts.env[String]("API_PATH", help = apiPathHelp)) orNone
 
   private val apiSchemeDefault = "http"
 
   private val apiSchemeHelp =
     s"Scheme server is exposed to end users with. Default: '$apiSchemeDefault'."
 
-  val apiScheme =
-    Opts
-      .option[String]("api-scheme", help = apiSchemeHelp) orElse
-      Opts.env[String]("API_SCHEME", help = apiSchemeHelp) withDefault ("http")
-  validate("Scheme must be either 'http' or 'https'")(s => (s == "http" || s == "https"))
+  val apiScheme = (Opts
+    .option[String]("api-scheme", help = apiSchemeHelp) orElse Opts
+    .env[String]("API_SCHEME", help = apiSchemeHelp))
+    .withDefault("http")
+    .validate(
+      "Scheme must be either 'http' or 'https'"
+    )(s => (s == "http" || s == "https"))
 
   private val defaultLimitDefault = NonNegInt(30)
 
   private val defaultLimitHelp =
     s"Default limit for items returned in paginated responses. Default: '$defaultLimitDefault'."
 
-  private val defaultLimit =
-    Opts
-      .option[NonNegInt]("default-limit", help = defaultLimitHelp) orElse
-      Opts.env[NonNegInt]("API_DEFAULT_LIMIT", help = defaultLimitHelp) withDefault (defaultLimitDefault)
+  private val defaultLimit = Opts
+    .option[NonNegInt]("default-limit", help = defaultLimitHelp) orElse Opts
+    .env[NonNegInt]("API_DEFAULT_LIMIT", help = defaultLimitHelp) withDefault (defaultLimitDefault)
 
   private val enableTransactionsHelp =
     "Whether to respond to transaction requests, like adding or updating items. Default: 'false'."
 
-  private val enableTransactions =
-    Opts
-      .flag(
-        "with-transactions",
-        help = enableTransactionsHelp
-      ) orElse
-      Opts.env[Boolean]("API_WITH_TRANSACTIONS", help = enableTransactionsHelp) orFalse
+  private val enableTransactions = Opts
+    .flag(
+      "with-transactions",
+      help = enableTransactionsHelp
+    )
+    .orFalse orElse Opts
+    .env[String]("API_WITH_TRANSACTIONS", help = enableTransactionsHelp, metavar = "true||false")
+    .mapValidated { s =>
+      if (Try(s.toBoolean).getOrElse(false)) Validated.valid(s.toBoolean)
+      else Validated.invalidNel("Value must be Boolean")
+    } withDefault (false)
 
   private val enableTilesHelp = "Whether to include tile endpoints. Default: 'false'."
 
-  private val enableTiles = Opts.flag("with-tiles", help = enableTilesHelp) orElse
-    Opts.env[Boolean]("API_WITH_TILES", help = enableTilesHelp) orFalse
-
-  private val runMigrationsHelp = "Run migrations before the API server starts. Default: 'false'."
+  private val enableTiles = Opts
+    .flag(
+      "with-tiles",
+      help = enableTilesHelp
+    )
+    .orFalse orElse Opts
+    .env[String]("API_WITH_TILES", help = enableTilesHelp, metavar = "true||false")
+    .mapValidated { s =>
+      if (Try(s.toBoolean).getOrElse(false)) Validated.valid(s.toBoolean)
+      else Validated.invalidNel("Value must be Boolean")
+    } withDefault (false)
 
   private val runMigrations =
-    Opts.flag("run-migrations", help = runMigrationsHelp) orElse
-      Opts.env[Boolean]("API_RUN_MIGRATIONS", help = runMigrationsHelp) orFalse
+    Opts.flag("run-migrations", "Run migrations before the API server starts").orFalse
 
   val apiConfig: Opts[ApiConfig] = (
     externalPort,

--- a/application/src/main/scala/com/azavea/franklin/commands/ApiOptions.scala
+++ b/application/src/main/scala/com/azavea/franklin/commands/ApiOptions.scala
@@ -75,8 +75,10 @@ trait ApiOptions {
     .orFalse orElse Opts
     .env[String]("API_WITH_TRANSACTIONS", help = enableTransactionsHelp, metavar = "true||false")
     .mapValidated { s =>
-      if (Try(s.toBoolean).getOrElse(false)) Validated.valid(s.toBoolean)
-      else Validated.invalidNel("Value must be Boolean")
+      Validated
+        .fromTry(Try(s.toBoolean))
+        .leftMap(_ => s"Expected to find a value that can convert to a Boolean, but got $s")
+        .toValidatedNel
     } withDefault (false)
 
   private val enableTilesHelp = "Whether to include tile endpoints. Default: 'false'."
@@ -89,8 +91,10 @@ trait ApiOptions {
     .orFalse orElse Opts
     .env[String]("API_WITH_TILES", help = enableTilesHelp, metavar = "true||false")
     .mapValidated { s =>
-      if (Try(s.toBoolean).getOrElse(false)) Validated.valid(s.toBoolean)
-      else Validated.invalidNel("Value must be Boolean")
+      Validated
+        .fromTry(Try(s.toBoolean))
+        .leftMap(_ => s"Expected to find a value that can convert to a Boolean, but got $s")
+        .toValidatedNel
     } withDefault (false)
 
   private val runMigrations =

--- a/application/src/main/scala/com/azavea/franklin/commands/ApiOptions.scala
+++ b/application/src/main/scala/com/azavea/franklin/commands/ApiOptions.scala
@@ -8,73 +8,80 @@ import eu.timepit.refined.types.numeric.PosInt
 
 trait ApiOptions {
 
-  private val portDefault = PosInt(9090)
+  private val portDefault      = PosInt(9090)
   private val externalPortHelp = s"Port users/clients hit for requests. Default: '$portDefault'."
+
   val externalPort = Opts
     .option[PosInt]("external-port", help = externalPortHelp) orElse
-    Opts.env[PosInt]("API_EXTERNAL_PORT", help = externalPortHelp)
-  withDefault(portDefault)
+    Opts.env[PosInt]("API_EXTERNAL_PORT", help = externalPortHelp) withDefault (portDefault)
 
   private val internalPortHelp =
     s"Port server listens on, this will be different from 'external-port' when service is started behind a proxy. Default: '$portDefault'."
+
   val internalPort = Opts
     .option[PosInt](
       "internal-port",
       help = internalPortHelp
-    ) orElse
-    Opts.env[PosInt]("API_INTERNAL_PORT", help = internalPortHelp)
-  withDefault(portDefault)
+    ) orElse Opts
+    .env[PosInt]("API_INTERNAL_PORT", help = internalPortHelp) withDefault (portDefault)
 
   private val apiHostDefault = "localhost"
-  private val apiHostHelp = s"Hostname Franklin is hosted it (e.g. localhost). Default: '$apiHostDefault'."
+
+  private val apiHostHelp =
+    s"Hostname Franklin is hosted it (e.g. localhost). Default: '$apiHostDefault'."
+
   val apiHost = Opts
     .option[String]("api-host", help = apiHostHelp) orElse
-    Opts.env[String]("API_HOST", help = apiHostHelp)
-  withDefault(apiHostDefault)
+    Opts.env[String]("API_HOST", help = apiHostHelp) withDefault (apiHostDefault)
 
   private val apiPathHelp = "Path component for root of Franklin instance (e.g. /stac/api)."
+
   val apiPath = Opts
     .option[String](
       "api-path",
       help = apiPathHelp
     ) orElse
-    Opts.env[String]("API_PATH", help = apiPathHelp)
-  orNone
+    Opts.env[String]("API_PATH", help = apiPathHelp) orNone
 
   private val apiSchemeDefault = "http"
-  private val apiSchemeHelp = s"Scheme server is exposed to end users with. Default: '$apiSchemeDefault'."
+
+  private val apiSchemeHelp =
+    s"Scheme server is exposed to end users with. Default: '$apiSchemeDefault'."
+
   val apiScheme =
     Opts
       .option[String]("api-scheme", help = apiSchemeHelp) orElse
-      Opts.env[String]("API_SCHEME", help = apiSchemeHelp)
-  withDefault("http")
+      Opts.env[String]("API_SCHEME", help = apiSchemeHelp) withDefault ("http")
   validate("Scheme must be either 'http' or 'https'")(s => (s == "http" || s == "https"))
 
   private val defaultLimitDefault = NonNegInt(30)
-  private val defaultLimitHelp = s"Default limit for items returned in paginated responses. Default: '$defaultLimitDefault'."
+
+  private val defaultLimitHelp =
+    s"Default limit for items returned in paginated responses. Default: '$defaultLimitDefault'."
+
   private val defaultLimit =
     Opts
       .option[NonNegInt]("default-limit", help = defaultLimitHelp) orElse
-      Opts.env[NonNegInt]("API_DEFAULT_LIMIT", help = defaultLimitHelp)
-  withDefault(defaultLimitDefault)
+      Opts.env[NonNegInt]("API_DEFAULT_LIMIT", help = defaultLimitHelp) withDefault (defaultLimitDefault)
 
   private val enableTransactionsHelp =
     "Whether to respond to transaction requests, like adding or updating items. Default: 'false'."
+
   private val enableTransactions =
     Opts
       .flag(
         "with-transactions",
         help = enableTransactionsHelp
       ) orElse
-      Opts.env[Boolean]("API_WITH_TRANSACTIONS", help = enableTransactionsHelp)
-  orFalse
+      Opts.env[Boolean]("API_WITH_TRANSACTIONS", help = enableTransactionsHelp) orFalse
 
   private val enableTilesHelp = "Whether to include tile endpoints. Default: 'false'."
+
   private val enableTiles = Opts.flag("with-tiles", help = enableTilesHelp) orElse
-    Opts.env[Boolean]("API_WITH_TILES", help = enableTilesHelp)
-  orFalse
+    Opts.env[Boolean]("API_WITH_TILES", help = enableTilesHelp) orFalse
 
   private val runMigrationsHelp = "Run migrations before the API server starts. Default: 'false'."
+
   private val runMigrations =
     Opts.flag("run-migrations", help = runMigrationsHelp) orElse
       Opts.env[Boolean]("API_RUN_MIGRATIONS", help = runMigrationsHelp) orFalse

--- a/application/src/main/scala/com/azavea/franklin/commands/ApiOptions.scala
+++ b/application/src/main/scala/com/azavea/franklin/commands/ApiOptions.scala
@@ -8,52 +8,76 @@ import eu.timepit.refined.types.numeric.PosInt
 
 trait ApiOptions {
 
+  private val portDefault = PosInt(9090)
+  private val externalPortHelp = s"Port users/clients hit for requests. Default: '$portDefault'."
   val externalPort = Opts
-    .option[PosInt]("external-port", help = "Port users/clients hit for requests")
-    .withDefault(PosInt(9090))
+    .option[PosInt]("external-port", help = externalPortHelp) orElse
+    Opts.env[PosInt]("API_EXTERNAL_PORT", help = externalPortHelp)
+  withDefault(portDefault)
 
+  private val internalPortHelp =
+    s"Port server listens on, this will be different from 'external-port' when service is started behind a proxy. Default: '$portDefault'."
   val internalPort = Opts
     .option[PosInt](
       "internal-port",
-      help =
-        "Port server listens on, this will be different from 'external-port' when service is started behind a proxy"
-    )
-    .withDefault(PosInt(9090))
+      help = internalPortHelp
+    ) orElse
+    Opts.env[PosInt]("API_INTERNAL_PORT", help = internalPortHelp)
+  withDefault(portDefault)
 
+  private val apiHostDefault = "localhost"
+  private val apiHostHelp = s"Hostname Franklin is hosted it (e.g. localhost). Default: '$apiHostDefault'."
   val apiHost = Opts
-    .option[String]("api-host", help = "Hostname Franklin is hosted it (e.g. localhost)")
-    .withDefault("localhost")
+    .option[String]("api-host", help = apiHostHelp) orElse
+    Opts.env[String]("API_HOST", help = apiHostHelp)
+  withDefault(apiHostDefault)
 
+  private val apiPathHelp = "Path component for root of Franklin instance (e.g. /stac/api)."
   val apiPath = Opts
     .option[String](
       "api-path",
-      help = "Path component for root of Franklin instance (e.g. /stac/api)"
-    )
-    .orNone
+      help = apiPathHelp
+    ) orElse
+    Opts.env[String]("API_PATH", help = apiPathHelp)
+  orNone
 
+  private val apiSchemeDefault = "http"
+  private val apiSchemeHelp = s"Scheme server is exposed to end users with. Default: '$apiSchemeDefault'."
   val apiScheme =
     Opts
-      .option[String]("api-scheme", "Scheme server is exposed to end users with")
-      .withDefault("http")
-      .validate("Scheme must be either 'http' or 'https'")(s => (s == "http" || s == "https"))
+      .option[String]("api-scheme", help = apiSchemeHelp) orElse
+      Opts.env[String]("API_SCHEME", help = apiSchemeHelp)
+  withDefault("http")
+  validate("Scheme must be either 'http' or 'https'")(s => (s == "http" || s == "https"))
 
+  private val defaultLimitDefault = NonNegInt(30)
+  private val defaultLimitHelp = s"Default limit for items returned in paginated responses. Default: '$defaultLimitDefault'."
   private val defaultLimit =
     Opts
-      .option[NonNegInt]("default-limit", "Default limit for items returned in paginated responses")
-      .withDefault(NonNegInt(30))
+      .option[NonNegInt]("default-limit", help = defaultLimitHelp) orElse
+      Opts.env[NonNegInt]("API_DEFAULT_LIMIT", help = defaultLimitHelp)
+  withDefault(defaultLimitDefault)
 
+  private val enableTransactionsHelp =
+    "Whether to respond to transaction requests, like adding or updating items. Default: 'false'."
   private val enableTransactions =
     Opts
       .flag(
         "with-transactions",
-        "Whether to respond to transaction requests, like adding or updating items"
-      )
-      .orFalse
+        help = enableTransactionsHelp
+      ) orElse
+      Opts.env[Boolean]("API_WITH_TRANSACTIONS", help = enableTransactionsHelp)
+  orFalse
 
-  private val enableTiles = Opts.flag("with-tiles", "Whether to include tile endpoints").orFalse
+  private val enableTilesHelp = "Whether to include tile endpoints. Default: 'false'."
+  private val enableTiles = Opts.flag("with-tiles", help = enableTilesHelp) orElse
+    Opts.env[Boolean]("API_WITH_TILES", help = enableTilesHelp)
+  orFalse
 
+  private val runMigrationsHelp = "Run migrations before the API server starts. Default: 'false'."
   private val runMigrations =
-    Opts.flag("run-migrations", "Run migrations before the API server starts").orFalse
+    Opts.flag("run-migrations", help = runMigrationsHelp) orElse
+      Opts.env[Boolean]("API_RUN_MIGRATIONS", help = runMigrationsHelp) orFalse
 
   val apiConfig: Opts[ApiConfig] = (
     externalPort,

--- a/application/src/main/scala/com/azavea/franklin/commands/DatabaseOptions.scala
+++ b/application/src/main/scala/com/azavea/franklin/commands/DatabaseOptions.scala
@@ -18,34 +18,36 @@ trait DatabaseOptions {
   private val databaseOptionDefault = "franklin"
 
   private val databasePortDefault = PosInt(5432)
-  private val databasePortHelp = s"Port to connect to database on. Default: '$databasePortDefault'."
+  private val databasePortHelp    = s"Port to connect to database on. Default: '$databasePortDefault'."
+
   private val databasePort = Opts
     .option[PosInt]("db-port", help = databasePortHelp) orElse
     Opts.env[PosInt]("DB_PORT", help = databasePortHelp) withDefault (databasePortDefault)
 
   private val databaseHostHelp = "Database host to connect to."
+
   private val databaseHost = Opts
     .option[String]("db-host", help = databaseHostHelp) orElse
-    Opts.env[String]("DB_HOST", help = databaseHostHelp)
-  withDefault("database.service.internal")
+    Opts.env[String]("DB_HOST", help = databaseHostHelp) withDefault ("database.service.internal")
 
   private val databaseNameHelp = s"Database name to connect to. Default: '$databaseOptionDefault'."
+
   private val databaseName = Opts
     .option[String]("db-name", help = databaseNameHelp) orElse
-    Opts.env[String]("DB_NAME", help = databaseNameHelp)
-  withDefault(databaseOptionDefault)
+    Opts.env[String]("DB_NAME", help = databaseNameHelp) withDefault (databaseOptionDefault)
 
   private val databasePasswordHelp = s"Database password to use. Default: '$databaseOptionDefault'."
+
   private val databasePassword = Opts
     .option[String]("db-password", help = databasePasswordHelp) orElse
-    Opts.env[String]("DB_PASSWORD", help = databasePasswordHelp)
-  withDefault(databaseOptionDefault)
+    Opts.env[String]("DB_PASSWORD", help = databasePasswordHelp) withDefault (databaseOptionDefault)
 
-  private val databaseUserHelp = s"User to connect with database with. Default: '$databaseOptionDefault'."
+  private val databaseUserHelp =
+    s"User to connect with database with. Default: '$databaseOptionDefault'."
+
   private val databaseUser = Opts
     .option[String]("db-user", help = databaseUserHelp) orElse
-    Opts.env[String]("DB_USER", help = databaseUserHelp)
-  withDefault(databaseOptionDefault)
+    Opts.env[String]("DB_USER", help = databaseUserHelp) withDefault (databaseOptionDefault)
 
   def databaseConfig(implicit contextShift: ContextShift[IO]): Opts[DatabaseConfig] =
     ((

--- a/application/src/main/scala/com/azavea/franklin/commands/DatabaseOptions.scala
+++ b/application/src/main/scala/com/azavea/franklin/commands/DatabaseOptions.scala
@@ -20,34 +20,30 @@ trait DatabaseOptions {
   private val databasePortDefault = PosInt(5432)
   private val databasePortHelp    = s"Port to connect to database on. Default: '$databasePortDefault'."
 
-  private val databasePort = Opts
-    .option[PosInt]("db-port", help = databasePortHelp) orElse
-    Opts.env[PosInt]("DB_PORT", help = databasePortHelp) withDefault (databasePortDefault)
+  private val databasePort = (Opts.option[PosInt]("db-port", help = databasePortHelp) orElse Opts
+    .env[PosInt]("DB_PORT", help = databasePortHelp)) withDefault (databasePortDefault)
 
   private val databaseHostHelp = "Database host to connect to."
 
-  private val databaseHost = Opts
-    .option[String]("db-host", help = databaseHostHelp) orElse
-    Opts.env[String]("DB_HOST", help = databaseHostHelp) withDefault ("database.service.internal")
+  private val databaseHost = (Opts.option[String]("db-host", help = databaseHostHelp) orElse Opts
+    .env[String]("DB_HOST", help = databaseHostHelp)) withDefault ("database.service.internal")
 
   private val databaseNameHelp = s"Database name to connect to. Default: '$databaseOptionDefault'."
 
-  private val databaseName = Opts
-    .option[String]("db-name", help = databaseNameHelp) orElse
-    Opts.env[String]("DB_NAME", help = databaseNameHelp) withDefault (databaseOptionDefault)
+  private val databaseName = (Opts.option[String]("db-name", help = databaseNameHelp) orElse Opts
+    .env[String]("DB_NAME", help = databaseNameHelp)) withDefault (databaseOptionDefault)
 
   private val databasePasswordHelp = s"Database password to use. Default: '$databaseOptionDefault'."
 
-  private val databasePassword = Opts
-    .option[String]("db-password", help = databasePasswordHelp) orElse
-    Opts.env[String]("DB_PASSWORD", help = databasePasswordHelp) withDefault (databaseOptionDefault)
+  private val databasePassword =
+    (Opts.option[String]("db-password", help = databasePasswordHelp) orElse Opts
+      .env[String]("DB_PASSWORD", help = databasePasswordHelp)) withDefault (databaseOptionDefault)
 
   private val databaseUserHelp =
     s"User to connect with database with. Default: '$databaseOptionDefault'."
 
-  private val databaseUser = Opts
-    .option[String]("db-user", help = databaseUserHelp) orElse
-    Opts.env[String]("DB_USER", help = databaseUserHelp) withDefault (databaseOptionDefault)
+  private val databaseUser = Opts.option[String]("db-user", help = databaseUserHelp) orElse Opts
+    .env[String]("DB_USER", help = databaseUserHelp) withDefault (databaseOptionDefault)
 
   def databaseConfig(implicit contextShift: ContextShift[IO]): Opts[DatabaseConfig] =
     ((

--- a/application/src/main/scala/com/azavea/franklin/commands/DatabaseOptions.scala
+++ b/application/src/main/scala/com/azavea/franklin/commands/DatabaseOptions.scala
@@ -15,25 +15,37 @@ import scala.util.Try
 
 trait DatabaseOptions {
 
+  private val databaseOptionDefault = "franklin"
+
+  private val databasePortDefault = PosInt(5432)
+  private val databasePortHelp = s"Port to connect to database on. Default: '$databasePortDefault'."
   private val databasePort = Opts
-    .option[PosInt]("db-port", help = "Port to connect to database on")
-    .withDefault(PosInt(5432))
+    .option[PosInt]("db-port", help = databasePortHelp) orElse
+    Opts.env[PosInt]("DB_PORT", help = databasePortHelp) withDefault (databasePortDefault)
 
+  private val databaseHostHelp = "Database host to connect to."
   private val databaseHost = Opts
-    .option[String]("db-host", help = "Database host to connect to")
-    .withDefault("database.service.internal")
+    .option[String]("db-host", help = databaseHostHelp) orElse
+    Opts.env[String]("DB_HOST", help = databaseHostHelp)
+  withDefault("database.service.internal")
 
+  private val databaseNameHelp = s"Database name to connect to. Default: '$databaseOptionDefault'."
   private val databaseName = Opts
-    .option[String]("db-name", help = "Database name to connect to")
-    .withDefault("franklin")
+    .option[String]("db-name", help = databaseNameHelp) orElse
+    Opts.env[String]("DB_NAME", help = databaseNameHelp)
+  withDefault(databaseOptionDefault)
 
+  private val databasePasswordHelp = s"Database password to use. Default: '$databaseOptionDefault'."
   private val databasePassword = Opts
-    .option[String]("db-password", help = "Database password to use")
-    .withDefault("franklin")
+    .option[String]("db-password", help = databasePasswordHelp) orElse
+    Opts.env[String]("DB_PASSWORD", help = databasePasswordHelp)
+  withDefault(databaseOptionDefault)
 
+  private val databaseUserHelp = s"User to connect with database with. Default: '$databaseOptionDefault'."
   private val databaseUser = Opts
-    .option[String]("db-user", help = "User to connect with database with")
-    .withDefault("franklin")
+    .option[String]("db-user", help = databaseUserHelp) orElse
+    Opts.env[String]("DB_USER", help = databaseUserHelp)
+  withDefault(databaseOptionDefault)
 
   def databaseConfig(implicit contextShift: ContextShift[IO]): Opts[DatabaseConfig] =
     ((

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -23,7 +23,7 @@ A [STAC](https://github.com/radiantearth/stac-spec) and [OGC API Features](http:
  - `serve` to start the API server
 
 ### Database configuration
-By default  `franklin` attempts to connect to a database named `franklin` at `localhost:5432` with a password of `franklin`. Using the following CLI options you can customize your database connection:
+By default  `franklin` attempts to connect to a database named `franklin` at `localhost:5432` with a password of `franklin`. Using the following CLI options you can customize your database connection*:
 
 ```bash
     --db-user <string>
@@ -37,6 +37,8 @@ By default  `franklin` attempts to connect to a database named `franklin` at `lo
     --db-name <string>
         Database name to connect to
 ```
+
+**Database connection options can also be set using environment variables: `DB_USER`, `DB_PASSWORD`, `DB_HOST`, `DB_PORT`, `DB_NAME`*
 
 ### Example commands
 
@@ -95,7 +97,7 @@ docker run \
 
 #### Running the service
 
-At this point you are ready to run the service. To start the service on the default port `9090` you can run the following command:
+At this point you are ready to run the service. To start the service on the default port `9090` you can run the `serve` command using `docker run`:
 
 ```bash
 docker run \
@@ -108,6 +110,30 @@ docker run \
   --db-password franklinsecret \
   --db-host franklin-database
 ```
+
+Additional API options and functionality can also be configured via the `franklin` CLI* by passing options to the `serve` command:
+
+```
+  --external-port 
+      Port users/clients hit for requests
+  --internal-port 
+      Port server listens on, this will be different from 'external-port' when service is started behind a proxy
+  --api-host 
+      Hostname Franklin is hosted it (e.g. localhost)
+  --api-path 
+      Path component for root of Franklin instance (e.g. /stac/api)
+  --api-scheme 
+      Scheme server is exposed to end users with
+  --default-limit 
+      Default limit for items returned in paginated responses
+  --with-transactions
+      Whether to respond to transaction requests, like adding or updating items
+  --with-tiles
+      Whether to include tile endpoints
+```
+
+**API options can also be set using environment variables: `API_EXTERNAL_PORT`, `API_INTERNAL_PORT`, `API_HOST`, `API_PATH`, `API_SCHEME`, `API_DEFAULT_LIMIT`, `API_WITH_TRANSACTIONS`, `API_WITH_TILES`*
+
 
 ### Using docker compose
 
@@ -141,10 +167,10 @@ services:
       - ./:/opt/franklin/
     environment:
       - ENVIRONMENT=development
-      - POSTGRES_URL=jdbc:postgresql://database.service.internal/
-      - POSTGRES_NAME=franklin
-      - POSTGRES_USER=franklin
-      - POSTGRES_PASSWORD=franklin
+      - DB_HOST=database.service.internal
+      - DB_NAME=franklin
+      - DB_USER=franklin
+      - DB_PASSWORD=franklin
     links:
       - database:database.service.internal
     ports:


### PR DESCRIPTION
## Overview

Adds support for using environment variables to configure `franklin's` database connection and api options as an alternative to using CLI commands.

### Checklist

- [x] New tests have been added or existing tests have been modified (No relevant tests needed modification)

### Notes

- Updated docs to include references to available environment variables.

### Testing Instructions

- Run `franklin serve` with relevant environment variables set.

Closes #393
