### PR TITLE
Use bulk insert for inserting STAC items

### DIFF
--- a/application/src/main/scala/com/azavea/franklin/api/Server.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/Server.scala
@@ -144,8 +144,8 @@ $$$$
             println(s"Import failed: $error")
             ExitCode.Error
           }
-          case Right(items) => {
-            println(s"Import succesful: ${items.size} items imported")
+          case Right(numItemsImported) => {
+            println(s"Import succesful: ${numItemsImported} items imported")
             ExitCode.Success
           }
         }

--- a/application/src/main/scala/com/azavea/franklin/crawler/StacItemImporter.scala
+++ b/application/src/main/scala/com/azavea/franklin/crawler/StacItemImporter.scala
@@ -31,7 +31,7 @@ class StacItemImporter(val collectionId: String, val itemUris: NonEmptyList[Stri
     EitherT.right(itemUris.traverse(uri => StacIO.readItem(uri, true, Some(collection.id))))
   }
 
-  def runIO(xa: Transactor[IO]): IO[Either[String, List[StacItem]]] = {
+  def runIO(xa: Transactor[IO]): IO[Either[String, Int]] = {
     for {
       collection <- getCollection(xa)
       itemList   <- readItems(collection)
@@ -42,14 +42,8 @@ class StacItemImporter(val collectionId: String, val itemUris: NonEmptyList[Stri
           List.empty,
           itemList.toList
         ).updateLinks
-        val items = collectionWrapper.items.traverse(item =>
-          StacItemDao
-            .insertStacItem(
-              item.copy(collection = Some(collectionId))
-            )
-            .transact(xa)
-        )
-        EitherT.right[String](items)
+        val amountInserted = StacItemDao.insertManyStacItems(collectionWrapper.items).transact(xa)
+        EitherT.right[String](amountInserted)
       }
     } yield {
       stacItems

--- a/application/src/main/scala/com/azavea/franklin/database/StacItemDao.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/StacItemDao.scala
@@ -11,11 +11,12 @@ import doobie.free.connection.ConnectionIO
 import doobie.implicits._
 import doobie.implicits.javatime._
 import doobie.refined.implicits._
+import doobie.util.update.Update
 import eu.timepit.refined.auto._
 import eu.timepit.refined.types.numeric.NonNegInt
 import eu.timepit.refined.types.numeric.PosInt
 import eu.timepit.refined.types.string.NonEmptyString
-import geotrellis.vector.Projected
+import geotrellis.vector.{Geometry, Projected}
 import io.circe.syntax._
 import io.circe.{DecodingFailure, Json}
 
@@ -120,6 +121,19 @@ object StacItemDao extends Dao[StacItem] {
       val metadata = Context(items.length, matched)
       StacSearchCollection(metadata, items, links)
     }
+  }
+
+  // This is only used to make the bulk insert happy and make the number of parameters line up
+  private case class StacItemBulkImport(id: String, geom: Projected[Geometry], item: StacItem)
+
+  def insertManyStacItems(items: List[StacItem]): ConnectionIO[Int] = {
+    val insertFragment  = """
+      INSERT INTO collection_items (id, geom, item)
+      VALUES
+      (?, ?, ?)
+      """
+    val stacItemInserts = items.map(i => StacItemBulkImport(i.id, Projected(i.geometry, 4326), i))
+    Update[StacItemBulkImport](insertFragment).updateMany(stacItemInserts)
   }
 
   def insertStacItem(item: StacItem): ConnectionIO[StacItem] = {


### PR DESCRIPTION
## Overview

Updates the item importer for better performance

### Testing Instructions

- Load the berlin-catalog from S3:
```
AWS_REGION=us-east-1 bloop run application -- import-catalog --db-host=localhost --catalog-root=s3://rasterfoundry-development-data-us-east-1/berlin-catalog/catalog.json
```
- After starting the server with transactions (`./scripts/server --with-transactions`), delete the mosaic item
```
http DELETE :9090/collections/berlin/items/Berlin+Sentinel+2+Mosaic
```
- Import an item into the collection
```
AWS_REGION=us-east-1 bloop run application -- import-items--db-host=localhost berlin s3://rasterfoundry-development-data-us-east-1/berlin-catalog/image/berlin-sentinel.json
```
- Delete the item again
- Save a file with only a single line which is the path to the mosaic item in S3
- Run an import
```
AWS_REGION=us-east-1 bloop run application -- import-items--db-host=localhost --file <path to file> berlin
```

