### PR TITLE
Make endpoints return more helpful json decode failures

### DIFF
--- a/application/src/main/scala/com/azavea/franklin/api/Server.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/Server.scala
@@ -43,6 +43,8 @@ object Server extends IOApp {
 
   override implicit val contextShift: ContextShift[IO] = franklinIO
 
+  implicit val serverOptions = ServerOptions.defaultServerOptions[IO]
+
   private val banner: List[String] =
     """
    $$$$$$$$$

--- a/application/src/main/scala/com/azavea/franklin/api/ServerOptions.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/ServerOptions.scala
@@ -1,0 +1,48 @@
+package com.azavea.franklin.api
+
+import io.circe.{CursorOp, DecodingFailure}
+import sttp.tapir.DecodeResult
+import sttp.tapir.server.{DecodeFailureContext, ServerDefaults}
+import sttp.tapir.server.http4s.Http4sServerOptions
+import cats.effect.{ContextShift, Sync}
+
+object ServerOptions {
+
+  private def handleDecodingErr(err: Throwable): Option[String] = err match {
+    case DecodingFailure("Attempt to decode value on failed cursor", history) =>
+      Some(
+        s"I expected to find a value at ${CursorOp.opsToPath(history)}, but there was nothing"
+      )
+    case DecodingFailure(s, history) =>
+      Some(
+        s"I found something unexpected at ${CursorOp.opsToPath(history)}. I expected a value of type $s"
+      )
+    case _ => None
+  }
+
+  private def failureMessage(ctx: DecodeFailureContext): String = {
+    ctx.failure match {
+      case DecodeResult.Mismatch(expected, actual) => s"Expected: $expected. Received: $actual"
+      case DecodeResult.Error(original, err)       => handleDecodingErr(err) getOrElse original
+      case _                                       => ServerDefaults.FailureMessages.failureMessage(ctx)
+    }
+  }
+
+  private val failureHandling =
+    ServerDefaults.decodeFailureHandler.copy(failureMessage = failureMessage)
+
+  /** Override the default decodeFailureHandler to produce nicer strings.
+    *
+    * Other overrideable values allow specifying how to produce the response message
+    * and how to go from decoding failures in different parts of a request (headers,
+    * query params, etc.) to a status code. For now, only the
+    * DecodeFailureContext => String
+    * has been overridden.
+    */
+  def defaultServerOptions[F[_]: Sync: ContextShift]: Http4sServerOptions[F] =
+    Http4sServerOptions
+      .default[F]
+      .copy(
+        decodeFailureHandler = failureHandling
+      )
+}

--- a/application/src/main/scala/com/azavea/franklin/api/ServerOptions.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/ServerOptions.scala
@@ -1,10 +1,10 @@
 package com.azavea.franklin.api
 
+import cats.effect.{ContextShift, Sync}
 import io.circe.{CursorOp, DecodingFailure}
 import sttp.tapir.DecodeResult
-import sttp.tapir.server.{DecodeFailureContext, ServerDefaults}
 import sttp.tapir.server.http4s.Http4sServerOptions
-import cats.effect.{ContextShift, Sync}
+import sttp.tapir.server.{DecodeFailureContext, ServerDefaults}
 
 object ServerOptions {
 

--- a/application/src/main/scala/com/azavea/franklin/api/services/CollectionItemsService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/CollectionItemsService.scala
@@ -35,12 +35,16 @@ import sttp.tapir.server.http4s._
 
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
+import sttp.tapir.DecodeResult
+import sttp.tapir.server.ServerDefaults
+import sttp.tapir.server.DecodeFailureContext
 
 class CollectionItemsService[F[_]: Sync](
     xa: Transactor[F],
     apiConfig: ApiConfig
 )(
-    implicit contextShift: ContextShift[F]
+    implicit contextShift: ContextShift[F],
+    serverOptions: Http4sServerOptions[F]
 ) extends Http4sDsl[F] {
 
   val apiHost            = apiConfig.apiHost

--- a/application/src/main/scala/com/azavea/franklin/api/services/CollectionItemsService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/CollectionItemsService.scala
@@ -31,13 +31,13 @@ import io.circe._
 import io.circe.syntax._
 import org.http4s.HttpRoutes
 import org.http4s.dsl.Http4sDsl
+import sttp.tapir.DecodeResult
+import sttp.tapir.server.DecodeFailureContext
+import sttp.tapir.server.ServerDefaults
 import sttp.tapir.server.http4s._
 
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
-import sttp.tapir.DecodeResult
-import sttp.tapir.server.ServerDefaults
-import sttp.tapir.server.DecodeFailureContext
 
 class CollectionItemsService[F[_]: Sync](
     xa: Transactor[F],

--- a/application/src/main/scala/com/azavea/franklin/api/services/CollectionsService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/CollectionsService.scala
@@ -25,7 +25,8 @@ class CollectionsService[F[_]: Sync](
     xa: Transactor[F],
     apiConfig: ApiConfig
 )(
-    implicit contextShift: ContextShift[F]
+    implicit contextShift: ContextShift[F],
+    serverOptions: Http4sServerOptions[F]
 ) extends Http4sDsl[F] {
 
   val apiHost            = apiConfig.apiHost

--- a/application/src/main/scala/com/azavea/franklin/api/services/SearchService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/SearchService.scala
@@ -22,7 +22,8 @@ class SearchService[F[_]: Sync](
     enableTiles: Boolean,
     xa: Transactor[F]
 )(
-    implicit contextShift: ContextShift[F]
+    implicit contextShift: ContextShift[F],
+    serverOptions: Http4sServerOptions[F]
 ) extends Http4sDsl[F] {
 
   def search(searchFilters: SearchFilters, searchMethod: SearchMethod): F[Either[Unit, Json]] = {


### PR DESCRIPTION
## Overview

This PR makes endpoints return more helpful messages when JSON decoding fails. It overrides the method to create
messages from decode failures with special handling for circe decoding failures.

### Checklist

- ~New tests have been added or existing tests have been modified~

### Notes

Unfortunately this only returns the first error. I believe that this is because tapir [just uses the `decode` function](https://github.com/softwaremill/tapir/blob/master/json/circe/src/main/scala/sttp/tapir/json/circe/TapirJsonCirce.scala#L15-L18) instead of the `decodeAccumulating` function for getting the circe decode result. We could also provide a closer derivation that would override this behavior.

Here are some example responses:

```
 $ echo '{}' | http :9090/collections/berlin/items
HTTP/1.1 400 Bad Request
Content-Length: 56
Content-Type: text/plain; charset=UTF-8
Date: Fri, 30 Oct 2020 21:26:22 GMT

I expected to find a value at .id, but there was nothing


 $ echo '{"id": 3}' | http :9090/collections/berlin/items
HTTP/1.1 400 Bad Request
Content-Length: 70
Content-Type: text/plain; charset=UTF-8
Date: Fri, 30 Oct 2020 21:26:33 GMT

I found something unexpected at .id. I expected a value of type String
```

### Testing Instructions

- start your server with transactions support -- `./scripts/server --with-transactions`
- send an obviously bogus request to the collections post endpoint: `echo '{}' | http :9090/collections`
- correct the error it tells you about and send another post -- `echo '{ YOUR CORRECTED JSON HERE }' | http :9090/collection`
- you should get different errors every time you do what the server asks you for until you end up with a valid collection

Closes #427
