### PR TITLE
Remove expensive counts from landing page

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-      - uses: olafurpg/setup-scala@v5
+      - uses: olafurpg/setup-scala@v10
       - name: Test Build
         run: |
           sbt docs/docusaurusCreateSite

--- a/application/src/main/resources/migrations/V7__add_collection_column_to_items.sql
+++ b/application/src/main/resources/migrations/V7__add_collection_column_to_items.sql
@@ -1,0 +1,11 @@
+ALTER TABLE collection_items ADD COLUMN collection text;
+
+CREATE TEMP TABLE collection_items_tmp AS (
+    SELECT id, geom, item, serial_id, created_at, item ->> 'collection' FROM collection_items
+);
+
+TRUNCATE TABLE collection_items;
+
+CREATE INDEX IF NOT EXISTS collection_items_collection_idx ON collection_items (collection);
+
+INSERT INTO collection_items (select * from collection_items_tmp);

--- a/application/src/main/scala/com/azavea/franklin/api/services/LandingPageService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/LandingPageService.scala
@@ -83,16 +83,12 @@ class LandingPageService[F[_]: Sync](apiConfig: ApiConfig, xa: Transactor[F])(
 
     for {
       collectionCount <- StacCollectionDao.getCollectionCount().transact(xa)
-      itemCount       <- StacItemDao.getItemCount().transact(xa)
-      assetCount      <- StacItemDao.getAssetCount().transact(xa)
       allCollections  <- StacCollectionDao.listCollections().transact(xa)
       landingPageJson <- Applicative[F].pure(landingPage.asJson)
     } yield {
       val text = franklin.html.index(
         landingPage,
         collectionCount,
-        itemCount,
-        assetCount,
         allCollections,
         apiConfig.apiHost
       )

--- a/application/src/main/scala/com/azavea/franklin/database/Filterables.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/Filterables.scala
@@ -94,7 +94,7 @@ trait Filterables extends GeotrellisWktMeta with FilterHelpers {
   implicit val searchFilter: Filterable[Any, SearchFilters] =
     Filterable[Any, SearchFilters] { searchFilters: SearchFilters =>
       val collectionsFilter: Option[Fragment] = searchFilters.collections.toNel
-        .map(collections => Fragments.in(fr"item ->> 'collection'", collections))
+        .map(collections => Fragments.in(fr"collection", collections))
       val idFilter: Option[Fragment] =
         searchFilters.items.toNel.map(ids => Fragments.in(fr"id", ids))
 

--- a/application/src/main/scala/com/azavea/franklin/database/StacItemDao.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/StacItemDao.scala
@@ -123,15 +123,21 @@ object StacItemDao extends Dao[StacItem] {
   }
 
   // This is only used to make the bulk insert happy and make the number of parameters line up
-  private case class StacItemBulkImport(id: String, geom: Projected[Geometry], item: StacItem, collection: Option[String])
+  private case class StacItemBulkImport(
+      id: String,
+      geom: Projected[Geometry],
+      item: StacItem,
+      collection: Option[String]
+  )
 
   def insertManyStacItems(items: List[StacItem]): ConnectionIO[Int] = {
-    val insertFragment  = """
+    val insertFragment = """
       INSERT INTO collection_items (id, geom, item, collection)
       VALUES
       (?, ?, ?, ?)
       """
-    val stacItemInserts = items.map(i => StacItemBulkImport(i.id, Projected(i.geometry, 4326), i, i.collection))
+    val stacItemInserts =
+      items.map(i => StacItemBulkImport(i.id, Projected(i.geometry, 4326), i, i.collection))
     Update[StacItemBulkImport](insertFragment).updateMany(stacItemInserts)
   }
 

--- a/application/src/main/twirl/com/azavea/franklin/index.scala.html
+++ b/application/src/main/twirl/com/azavea/franklin/index.scala.html
@@ -3,7 +3,7 @@
 @import com.azavea.stac4s.StacLinkType
 @import com.azavea.stac4s.StacCollection
 
-@(landingPage: LandingPage, collectionCount: Int, itemCount: Int, assetCount: Int, collectionList: List[StacCollection],
+@(landingPage: LandingPage, collectionCount: Int, collectionList: List[StacCollection],
 apiHost: String)
 
 <!DOCTYPE html>
@@ -48,18 +48,6 @@ apiHost: String)
               <article class="tile is-child box">
                 <p class="title">@collectionCount</p>
                 <p class="subtitle">Collections</p>
-              </article>
-            </div>
-            <div class="tile is-parent">
-              <article class="tile is-child box">
-                <p class="title">@itemCount</p>
-                <p class="subtitle">Items</p>
-              </article>
-            </div>
-            <div class="tile is-parent">
-              <article class="tile is-child box">
-                <p class="title">@assetCount</p>
-                <p class="subtitle">Assets</p>
               </article>
             </div>
           </div>


### PR DESCRIPTION
## Overview

This PR removes the item and asset counts from the landing page. For large numbers of items / assets, they cause the landing page to hang forever.

### Checklist

- ~New tests have been added or existing tests have been modified~

### Testing Instructions

- load a bunch of items into your database. I used this goofy python function with one of our sample items loaded as `js` to load 500k of them, but you can also just ask me to demo since i have 1.5 million items loaded currently

```python
def new_item():
    copied = js.copy()
    copied["id"] = str(uuid4())
    resp = requests.post("http://localhost:9090/collections/berlin/items", json=copied)
    resp.raise_for_status()
```

- rebuild frontend assets -- `./scripts/update`
- bring up your server
- navigate to `http://localhost:9090` and confirm the page doesn't hang
- navigate to `http://localhost:9090/collections/<collection id>/items` for the collection that has all your items in it -- it should be 🏎
