### PR TITLE
Fix eager s3 client and too many open files bugs

### DIFF
--- a/application/src/main/scala/com/azavea/franklin/commands/Commands.scala
+++ b/application/src/main/scala/com/azavea/franklin/commands/Commands.scala
@@ -11,6 +11,7 @@ import doobie.Transactor
 import doobie.free.connection.{rollback, setAutoCommit, unit}
 import doobie.util.transactor.Strategy
 import org.flywaydb.core.Flyway
+import sttp.client.{NothingT, SttpBackend}
 
 object Commands {
 
@@ -78,7 +79,7 @@ object Commands {
       itemUris: NonEmptyList[String],
       config: DatabaseConfig,
       dryRun: Boolean
-  )(implicit cs: ContextShift[IO]) = {
+  )(implicit cs: ContextShift[IO], backend: SttpBackend[IO, Nothing, NothingT]) = {
     val xa = config.getTransactor(dryRun)
     new StacItemImporter(collectionId, itemUris).runIO(xa)
   }
@@ -88,7 +89,8 @@ object Commands {
       config: DatabaseConfig,
       dryRun: Boolean
   )(
-      implicit contextShift: ContextShift[IO]
+      implicit contextShift: ContextShift[IO],
+      backend: SttpBackend[IO, Nothing, NothingT]
   ): IO[Unit] = {
     val xa = config.getTransactor(dryRun)
     new CatalogStacImport(stacCatalog).runIO(xa)

--- a/application/src/main/scala/com/azavea/franklin/crawler/StacIO.scala
+++ b/application/src/main/scala/com/azavea/franklin/crawler/StacIO.scala
@@ -37,7 +37,7 @@ object StacIO {
   private def logBadResponse(path: String, code: Int)(implicit logger: Logger[IO]): IO[Unit] =
     logger.error(s"The server responsible for $path rejected my request with a status of $code")
 
-  val s3 = AmazonS3ClientBuilder
+  lazy val s3 = AmazonS3ClientBuilder
     .standard()
     .withForceGlobalBucketAccessEnabled(true)
     .build()

--- a/application/src/main/scala/com/azavea/franklin/crawler/StacItemImporter.scala
+++ b/application/src/main/scala/com/azavea/franklin/crawler/StacItemImporter.scala
@@ -10,9 +10,11 @@ import com.azavea.stac4s._
 import doobie.implicits._
 import doobie.util.transactor.Transactor
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import sttp.client.{NothingT, SttpBackend}
 
 class StacItemImporter(val collectionId: String, val itemUris: NonEmptyList[String])(
-    implicit contextShift: ContextShift[IO]
+    implicit contextShift: ContextShift[IO],
+    backend: SttpBackend[IO, Nothing, NothingT]
 ) {
 
   implicit def logger = Slf4jLogger.getLogger[IO]


### PR DESCRIPTION
## Overview

This PR makes it so:

- the s3 client is lazy, so you can start the importer without an AWS profile set and not have the AWS sdk yell at you
- there's only one sttp backend instead of one sttp backend per path, so when you import a large https catalog it doesn't explode from opening too many file handles

### Checklist

- ~New tests have been added or existing tests have been modified~

### Testing Instructions

- run the command from #482 without an AWS_PROFILE set (or with a bogus one set, if you have a `default` profile)

Closes #482 

Closes #480 
