### PR TITLE
adding open-api docs reference to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ This will start a [server](http://localhost:9090) without data using a provided 
 
 ## Features Implemented
 
+Franklin serves api documentation at `/open-api/spec.yaml`, which shows what is available given then flags it is run with. 
+
 ### STAC Core
 #### Capabilities
 - [x] `GET /`


### PR DESCRIPTION
## Overview

Small addition to README to reference the open-api documentation. 
