### PR TITLE
Set collection id on item post

### DIFF
--- a/application/src/main/scala/com/azavea/franklin/api/services/CollectionItemsService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/CollectionItemsService.scala
@@ -175,7 +175,8 @@ class CollectionItemsService[F[_]: Sync](
           )
         }
       case None =>
-        val withParent = item.copy(links = fallbackCollectionLink +: item.links)
+        val withParent =
+          item.copy(links = fallbackCollectionLink +: item.links, collection = Some(collectionId))
         StacItemDao.insertStacItem(withParent).transact(xa) map { inserted =>
           val validated = validateItemAndLinks(inserted)
           Right((validated.asJson, validated.##.toString))

--- a/application/src/test/scala/com/azavea/franklin/api/TestClient.scala
+++ b/application/src/test/scala/com/azavea/franklin/api/TestClient.scala
@@ -50,7 +50,7 @@ class TestClient[F[_]: Sync](
       Request(
         method = Method.POST,
         uri = Uri.unsafeFromString(s"/collections/$encodedCollectionId/items")
-      ).withEntity(item.copy(collection=None))
+      ).withEntity(item)
     ) flatMap { _.as[StacItem] }
   }
 
@@ -68,7 +68,7 @@ class TestClient[F[_]: Sync](
   }
 
   def getItemResource(collection: StacCollection, item: StacItem): Resource[F, StacItem] =
-    Resource.make(createItemInCollection(collection, item.copy(collection = Some(collection.id))))(
+    Resource.make(createItemInCollection(collection, item))(
       item => deleteItemInCollection(collection, item)
     )
 

--- a/application/src/test/scala/com/azavea/franklin/api/TestClient.scala
+++ b/application/src/test/scala/com/azavea/franklin/api/TestClient.scala
@@ -50,7 +50,7 @@ class TestClient[F[_]: Sync](
       Request(
         method = Method.POST,
         uri = Uri.unsafeFromString(s"/collections/$encodedCollectionId/items")
-      ).withEntity(item)
+      ).withEntity(item.copy(collection=None))
     ) flatMap { _.as[StacItem] }
   }
 

--- a/application/src/test/scala/com/azavea/franklin/api/TestClient.scala
+++ b/application/src/test/scala/com/azavea/franklin/api/TestClient.scala
@@ -68,8 +68,8 @@ class TestClient[F[_]: Sync](
   }
 
   def getItemResource(collection: StacCollection, item: StacItem): Resource[F, StacItem] =
-    Resource.make(createItemInCollection(collection, item))(
-      item => deleteItemInCollection(collection, item)
+    Resource.make(createItemInCollection(collection, item))(item =>
+      deleteItemInCollection(collection, item)
     )
 
   def getCollectionResource(collection: StacCollection): Resource[F, StacCollection] =

--- a/application/src/test/scala/com/azavea/franklin/api/TestClient.scala
+++ b/application/src/test/scala/com/azavea/franklin/api/TestClient.scala
@@ -50,7 +50,7 @@ class TestClient[F[_]: Sync](
       Request(
         method = Method.POST,
         uri = Uri.unsafeFromString(s"/collections/$encodedCollectionId/items")
-      ).withEntity(item.copy(collection=None))
+      ).withEntity(item.copy(collection = None))
     ) flatMap { _.as[StacItem] }
   }
 


### PR DESCRIPTION
## Overview

This PR makes it so that we set the `collection` attribute of items on item post. This ensures that items posted without a collection id set can still be found in the collection they're posted to.

### Checklist

- [x] New tests have been added or existing tests have been modified

### Notes

The collection id from the URL will only get set if the collection attribute isn't set on the item -- otherwise the route ensures that those two values match, and if not tells you that you did a bad job.

### Testing Instructions

- confirm test change exercises the collection-less item post

Closes #414 

Closes #520
