### PR TITLE
Acquire implicit context shift in resource

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,3 @@
-addSbtPlugin("ch.epfl.scala"             % "sbt-bloop"                 % "1.4.6")
 addSbtPlugin("org.lyranthe.sbt"          % "partial-unification"       % "1.1.0")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"              % "0.1.16")
 addSbtPlugin("io.spray"                  % "sbt-revolver"              % "0.9.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,6 @@ addSbtPlugin("com.sksamuel.scapegoat"    %% "sbt-scapegoat"            % "1.1.0"
 addSbtPlugin("ch.epfl.scala"             % "sbt-scalafix"              % "0.9.25")
 addSbtPlugin("com.eed3si9n"              % "sbt-assembly"              % "0.14.9")
 addSbtPlugin("com.github.cb372"          % "sbt-explicit-dependencies" % "0.2.16")
-addSbtPlugin("org.scalameta"             % "sbt-mdoc"                  % "2.2.16")
 addSbtPlugin("org.jmotor.sbt"            % "sbt-dependency-updates"    % "1.2.2")
 addSbtPlugin("com.typesafe.sbt"          % "sbt-twirl"                 % "1.5.0")
+addSbtPlugin("org.scalameta"             % "sbt-mdoc"                  % "2.2.14")


### PR DESCRIPTION
## Overview

This PR acquires the threadpool for the `IO` `contextShift` override in a `Resource`, which allows us to specify shutdown on cleanup. The `Resource` context exits when the server process is complete, which triggers the `pool.shutdown` call.

### Checklist

- ~New tests have been added or existing tests have been modified~

### Testing Instructions

- run migrations (even though there aren't any here) -- the process should exit

Closes #545
