### PR TITLE
Acquire sttp backend in resource

### DIFF
--- a/application/src/main/scala/com/azavea/franklin/api/Server.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/Server.scala
@@ -144,11 +144,11 @@ $$$$
           createServer(apiConfig, dbConfig).use(_ => IO.never).as(ExitCode.Success)
       case RunMigrations(config) => runMigrations(config)
       case RunCatalogImport(catalogRoot, dbConfig, dryRun) =>
-        AsyncHttpClientCatsBackend[IO]() flatMap { implicit backend =>
+        AsyncHttpClientCatsBackend.resource[IO]() use { implicit backend =>
           runCatalogImport(catalogRoot, dbConfig, dryRun) map { _ => ExitCode.Success }
         }
       case RunItemsImport(collectionId, itemUris, dbConfig, dryRun) => {
-        AsyncHttpClientCatsBackend[IO]() flatMap { implicit backend =>
+        AsyncHttpClientCatsBackend.resource[IO]() use { implicit backend =>
           runStacItemImport(collectionId, itemUris, dbConfig, dryRun) map {
             case Left(error) => {
               println(s"Import failed: $error")


### PR DESCRIPTION
## Overview

This PR acquires the STTP backend in a resource with pre-defined shutdown behavior. It prevents the STTP-managed threads from hanging out after the program has completed.

### Checklist

- ~New tests have been added or existing tests have been modified~

### Notes

I think I tried this manually before? Like, `Resource.liftF`-ing maybe? I remember kind of trying this strategy and having it not work out. oh well. Works now.

### Testing Instructions

- launch sbt with the log level set to debug: `FRANKLIN_LOG_LEVEL=DEBUG sbt`
- bring up your database: `docker-compose up -d database`
- run a catalog import and confirm that you're trying to read from urls: `application/run import-catalog --catalog-root https://raw.githubusercontent.com/azavea/stac-layer/main/stac-spec/layer/examples/landsat-stac-layers/catalog.json --db-host=localhost`
- you won't get any items into the database, but you'll definitely read from some urls, and the process will exit

Closes #609 (if applicable)
