### PR TITLE
Update collection extents when items change

### DIFF
--- a/application/src/main/resources/migrations/V9__make_collection_an_fk.sql
+++ b/application/src/main/resources/migrations/V9__make_collection_an_fk.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+    collection_items
+ADD
+    CONSTRAINT collection_collections_fk FOREIGN KEY (collection) REFERENCES collections(id) ON DELETE CASCADE;

--- a/application/src/main/scala/com/azavea/franklin/api/services/CollectionItemsService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/CollectionItemsService.scala
@@ -237,7 +237,8 @@ class CollectionItemsService[F[_]: Concurrent](
         etag
       )
       .transact(xa) map {
-      case None | Some(Left(StacItemDao.ItemNotFound)) =>
+      case None | Some(Left(StacItemDao.ItemNotFound)) |
+          Some(Left(StacItemDao.CollectionNotFound)) =>
         Left(NF(s"Item $itemId in collection $collectionId not found"))
       case Some(Left(StacItemDao.StaleObject)) =>
         Left(MidAirCollision(s"Item $itemId changed server side. Refresh object and try again"))

--- a/application/src/main/scala/com/azavea/franklin/api/services/CollectionsService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/CollectionsService.scala
@@ -50,7 +50,7 @@ class CollectionsService[F[_]: Concurrent](
     val collectionId = URLDecoder.decode(rawCollectionId, StandardCharsets.UTF_8.toString)
     for {
       collectionOption <- StacCollectionDao
-        .getCollectionUnique(collectionId)
+        .getCollection(collectionId)
         .transact(xa)
     } yield {
       Either.fromOption(
@@ -66,7 +66,7 @@ class CollectionsService[F[_]: Concurrent](
     val collectionId = URLDecoder.decode(rawCollectionId, StandardCharsets.UTF_8.toString)
     for {
       collectionOption <- StacCollectionDao
-        .getCollectionUnique(collectionId)
+        .getCollection(collectionId)
         .transact(xa)
     } yield {
       Either.fromOption(
@@ -111,7 +111,7 @@ class CollectionsService[F[_]: Concurrent](
     val collectionId = URLDecoder.decode(rawCollectionId, StandardCharsets.UTF_8.toString)
     for {
       collectionOption <- StacCollectionDao
-        .getCollectionUnique(collectionId)
+        .getCollection(collectionId)
         .transact(xa)
       deleted <- collectionOption traverse { _ =>
         StacCollectionDao.query.filter(fr"id = $collectionId").delete.transact(xa).void

--- a/application/src/main/scala/com/azavea/franklin/api/services/TileService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/TileService.scala
@@ -132,7 +132,7 @@ class TileService[F[_]: Concurrent: LiftIO](
   ): F[Either[NF, Json]] = {
     val decoded = URLDecoder.decode(collectionId, StandardCharsets.UTF_8.toString)
     for {
-      collectionO <- StacCollectionDao.getCollectionUnique(decoded).transact(xa)
+      collectionO <- StacCollectionDao.getCollection(decoded).transact(xa)
     } yield {
       Either.fromOption(
         collectionO map { collection =>

--- a/application/src/main/scala/com/azavea/franklin/crawler/StacItemImporter.scala
+++ b/application/src/main/scala/com/azavea/franklin/crawler/StacItemImporter.scala
@@ -45,10 +45,12 @@ class StacItemImporter(val collectionId: String, val itemUris: NonEmptyList[Stri
         ).updateLinks
         val amountInserted = (
           StacItemDao.insertManyStacItems(collectionWrapper.items)
-            <* StacCollectionDao.updateExtent(
-              collectionId,
-              getItemsBulkExtent(collectionWrapper.items)
-            )
+            <* (collectionWrapper.items.toNel traverse { itemNel =>
+              StacCollectionDao.updateExtent(
+                collectionId,
+                getItemsBulkExtent(itemNel)
+              )
+            })
         ).transact(xa)
         EitherT.right[String](amountInserted)
       }

--- a/application/src/main/scala/com/azavea/franklin/crawler/StacItemImporter.scala
+++ b/application/src/main/scala/com/azavea/franklin/crawler/StacItemImporter.scala
@@ -20,7 +20,7 @@ class StacItemImporter(val collectionId: String, val itemUris: NonEmptyList[Stri
 
   private def getCollection(xa: Transactor[IO]): EitherT[IO, String, StacCollection] =
     EitherT {
-      StacCollectionDao.getCollectionUnique(collectionId).transact(xa).map { collectionOption =>
+      StacCollectionDao.getCollection(collectionId).transact(xa).map { collectionOption =>
         Either
           .fromOption(collectionOption, s"Could not read collection: $collectionId from database")
       }

--- a/application/src/main/scala/com/azavea/franklin/database/StacCollectionDao.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/StacCollectionDao.scala
@@ -30,20 +30,16 @@ object StacCollectionDao extends Dao[StacCollection] {
     sql"select count(*) from collections".query[Int].unique
   }
 
-  def getCollectionUnique(
+  def getCollection(
       collectionId: String
-  ): ConnectionIO[Option[StacCollection]] = {
-    (selectF ++ Fragments.whereAnd(
-      fr"id = $collectionId"
-    )).query[StacCollection].option
-  }
+  ): ConnectionIO[Option[StacCollection]] = query.filter(fr"id = $collectionId").selectOption
 
   def insertStacCollection(
       collection: StacCollection,
       parentId: Option[String]
   ): ConnectionIO[StacCollection] = {
 
-    OptionT { getCollectionUnique(collection.id) } getOrElseF {
+    OptionT { getCollection(collection.id) } getOrElseF {
       val insertFragment = fr"""
       INSERT INTO collections (id, parent, collection)
       VALUES

--- a/application/src/main/scala/com/azavea/franklin/database/StacCollectionDao.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/StacCollectionDao.scala
@@ -3,7 +3,7 @@ package com.azavea.franklin.database
 import cats.data.OptionT
 import cats.syntax.foldable._
 import cats.syntax.list._
-import com.azavea.franklin.datamodel.MapboxVectorTileFootprintRequest
+import com.azavea.franklin.datamodel.{BulkExtent, MapboxVectorTileFootprintRequest}
 import com.azavea.stac4s._
 import doobie._
 import doobie.free.connection.ConnectionIO
@@ -20,6 +20,11 @@ object StacCollectionDao extends Dao[StacCollection] {
   def listCollections(): ConnectionIO[List[StacCollection]] = {
     selectF.query[StacCollection].to[List]
   }
+
+  private[database] def updateExtent(
+      collectionId: String,
+      bulkExtent: BulkExtent
+  ): ConnectionIO[Option[StacCollection]] = ???
 
   def getCollectionCount(): ConnectionIO[Int] = {
     sql"select count(*) from collections".query[Int].unique

--- a/application/src/main/scala/com/azavea/franklin/database/StacCollectionDao.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/StacCollectionDao.scala
@@ -31,8 +31,9 @@ object StacCollectionDao extends Dao[StacCollection] {
     (OptionT(getCollection(collectionId)) flatMap { collection =>
       val existingExtent = collection.extent
       val newBbox = existingExtent.spatial.bbox match {
-        case h :: t => (bulkExtent.bbox map { h.union(_) } getOrElse h) :: t
-        case Nil    => bulkExtent.bbox.toList
+        case h :: t =>
+          (bulkExtent.bbox map { h.union(_) } getOrElse h) :: t
+        case Nil => bulkExtent.bbox.toList
       }
 
       val newTemporal = existingExtent.temporal.interval.map(_.value) match {

--- a/application/src/main/scala/com/azavea/franklin/database/StacCollectionDao.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/StacCollectionDao.scala
@@ -21,7 +21,7 @@ object StacCollectionDao extends Dao[StacCollection] {
     selectF.query[StacCollection].to[List]
   }
 
-  private[database] def updateExtent(
+  def updateExtent(
       collectionId: String,
       bulkExtent: BulkExtent
   ): ConnectionIO[Option[StacCollection]] = ???

--- a/application/src/main/scala/com/azavea/franklin/database/StacCollectionDao.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/StacCollectionDao.scala
@@ -30,10 +30,10 @@ object StacCollectionDao extends Dao[StacCollection] {
   ): ConnectionIO[Int] =
     (OptionT(getCollection(collectionId)) flatMap { collection =>
       val existingExtent = collection.extent
-      val newBbox = existingExtent.spatial.bbox match {
+      val newBbox: List[Bbox] = existingExtent.spatial.bbox match {
         case h :: t =>
-          (bulkExtent.bbox map { h.union(_) } getOrElse h) :: t
-        case Nil => bulkExtent.bbox.toList
+          h.union(bulkExtent.bbox) :: t
+        case Nil => List(bulkExtent.bbox)
       }
 
       val newTemporal = existingExtent.temporal.interval.map(_.value) match {

--- a/application/src/main/scala/com/azavea/franklin/database/StacCollectionDao.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/StacCollectionDao.scala
@@ -5,12 +5,13 @@ import cats.syntax.foldable._
 import cats.syntax.list._
 import com.azavea.franklin.datamodel.{BulkExtent, MapboxVectorTileFootprintRequest}
 import com.azavea.stac4s._
+import com.azavea.stac4s.types.TemporalExtent
 import doobie._
 import doobie.free.connection.ConnectionIO
 import doobie.implicits._
 import doobie.refined.implicits._
 import eu.timepit.refined.types.string.NonEmptyString
-import com.azavea.stac4s.types.TemporalExtent
+
 import java.time.Instant
 
 object StacCollectionDao extends Dao[StacCollection] {

--- a/application/src/main/scala/com/azavea/franklin/database/StacItemDao.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/StacItemDao.scala
@@ -1,14 +1,13 @@
 package com.azavea.franklin.database
 
-import cats.data.{EitherT, OptionT}
+import cats.data.EitherT
+import cats.data.OptionT
 import cats.syntax.all._
-import com.azavea.franklin.datamodel.{
-  BulkExtent,
-  Context,
-  PaginationToken,
-  SearchMethod,
-  StacSearchCollection
-}
+import com.azavea.franklin.datamodel.BulkExtent
+import com.azavea.franklin.datamodel.Context
+import com.azavea.franklin.datamodel.PaginationToken
+import com.azavea.franklin.datamodel.SearchMethod
+import com.azavea.franklin.datamodel.StacSearchCollection
 import com.azavea.franklin.extensions.paging.PagingLinkExtension
 import com.azavea.stac4s._
 import com.azavea.stac4s.syntax._
@@ -22,9 +21,11 @@ import eu.timepit.refined.auto._
 import eu.timepit.refined.types.numeric.NonNegInt
 import eu.timepit.refined.types.numeric.PosInt
 import eu.timepit.refined.types.string.NonEmptyString
-import geotrellis.vector.{Geometry, Projected}
+import geotrellis.vector.Geometry
+import geotrellis.vector.Projected
+import io.circe.DecodingFailure
+import io.circe.Json
 import io.circe.syntax._
-import io.circe.{DecodingFailure, Json}
 
 import java.time.Instant
 

--- a/application/src/main/scala/com/azavea/franklin/database/StacItemDao.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/StacItemDao.scala
@@ -1,6 +1,7 @@
 package com.azavea.franklin.database
 
 import cats.data.EitherT
+import cats.data.NonEmptyList
 import cats.data.OptionT
 import cats.syntax.all._
 import com.azavea.franklin.datamodel.BulkExtent
@@ -28,7 +29,6 @@ import io.circe.Json
 import io.circe.syntax._
 
 import java.time.Instant
-import cats.data.NonEmptyList
 
 object StacItemDao extends Dao[StacItem] {
 

--- a/application/src/main/scala/com/azavea/franklin/database/StacItemDao.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/StacItemDao.scala
@@ -194,12 +194,6 @@ object StacItemDao extends Dao[StacItem] {
     fragment.update.withUniqueGeneratedKeys[StacItem]("item")
   }
 
-  // TODO if an item's new geometry _at least contains_ its previous geometry,
-  // update the item's collection's extent the normal way
-  // if it's smaller, we have less information -- the extent _might_ need to change
-  // but might not, so recalculate the item's collection's extent in the background
-  // also recalculate extent in the background for deletes.
-  // actual "ship it to the background" will happen in services.
   def updateStacItem(
       collectionId: String,
       itemId: String,
@@ -215,7 +209,6 @@ object StacItemDao extends Dao[StacItem] {
           ItemNotFound: StacItemDaoError
         )
       etagInDb = itemInDB.##
-      // todo expand spatial extents
       update <- if (etagInDb.toString == etag) {
         EitherT { doUpdate(itemId, item).attempt } leftMap { _ => UpdateFailed: StacItemDaoError }
       } else {

--- a/application/src/main/scala/com/azavea/franklin/database/database.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/database.scala
@@ -1,17 +1,17 @@
 package com.azavea.franklin
 
 import cats.syntax.all._
+import com.azavea.franklin.datamodel.BulkExtent
+import com.azavea.stac4s.StacItem
 import com.azavea.stac4s.types.TemporalExtent
 import doobie.implicits.javasql._
 import doobie.util.meta.Meta
 import doobie.util.{Read, Write}
-import io.circe.{Decoder, Encoder}
 import io.circe.syntax._
+import io.circe.{Decoder, Encoder}
 
 import java.sql.Timestamp
 import java.time.Instant
-import com.azavea.stac4s.StacItem
-import com.azavea.franklin.datamodel.BulkExtent
 
 package object database extends CirceJsonbMeta with GeotrellisWktMeta with Filterables {
 

--- a/application/src/main/scala/com/azavea/franklin/database/database.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/database.scala
@@ -60,7 +60,7 @@ package object database extends CirceJsonbMeta with GeotrellisWktMeta with Filte
     }
   }
 
-  def getItemsBulkExtent(items: List[StacItem]) =
+  def getItemsBulkExtent(items: List[StacItem]): BulkExtent =
     items.foldLeft(BulkExtent(None, None, None))({
       case (BulkExtent(start, end, bbox), item) => {
         val itemDt   = item.properties.asJson.hcursor.downField("datetime").as[Instant].toOption

--- a/application/src/main/scala/com/azavea/franklin/database/database.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/database.scala
@@ -1,22 +1,19 @@
 package com.azavea.franklin
 
+import cats.data.NonEmptyList
 import cats.syntax.all._
 import com.azavea.franklin.datamodel.BulkExtent
-import com.azavea.stac4s.StacItem
+import com.azavea.stac4s.{Bbox, StacItem, ThreeDimBbox, TwoDimBbox}
 import com.azavea.stac4s.types.TemporalExtent
 import doobie.implicits.javasql._
 import doobie.util.meta.Meta
 import doobie.util.{Read, Write}
+import geotrellis.vector.Extent
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder}
 
 import java.sql.Timestamp
 import java.time.Instant
-import cats.data.NonEmptyList
-import com.azavea.stac4s.Bbox
-import geotrellis.vector.Extent
-import com.azavea.stac4s.ThreeDimBbox
-import com.azavea.stac4s.TwoDimBbox
 
 package object database extends CirceJsonbMeta with GeotrellisWktMeta with Filterables {
 

--- a/application/src/main/scala/com/azavea/franklin/database/database.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/database.scala
@@ -3,8 +3,8 @@ package com.azavea.franklin
 import cats.data.NonEmptyList
 import cats.syntax.all._
 import com.azavea.franklin.datamodel.BulkExtent
-import com.azavea.stac4s.{Bbox, StacItem, ThreeDimBbox, TwoDimBbox}
 import com.azavea.stac4s.types.TemporalExtent
+import com.azavea.stac4s.{Bbox, StacItem, ThreeDimBbox, TwoDimBbox}
 import doobie.implicits.javasql._
 import doobie.util.meta.Meta
 import doobie.util.{Read, Write}

--- a/application/src/main/scala/com/azavea/franklin/datamodel/BulkExtent.scala
+++ b/application/src/main/scala/com/azavea/franklin/datamodel/BulkExtent.scala
@@ -1,0 +1,10 @@
+package com.azavea.franklin.datamodel
+
+import java.time.Instant
+import com.azavea.stac4s.Bbox
+
+final case class BulkExtent(
+    start: Option[Instant],
+    end: Option[Instant],
+    bbox: Option[Bbox]
+)

--- a/application/src/main/scala/com/azavea/franklin/datamodel/BulkExtent.scala
+++ b/application/src/main/scala/com/azavea/franklin/datamodel/BulkExtent.scala
@@ -1,11 +1,13 @@
 package com.azavea.franklin.datamodel
 
-import com.azavea.stac4s.Bbox
+import com.azavea.stac4s.TwoDimBbox
+
+import geotrellis.vector.Extent
 
 import java.time.Instant
 
 final case class BulkExtent(
     start: Option[Instant],
     end: Option[Instant],
-    bbox: Option[Bbox]
+    bbox: TwoDimBbox
 )

--- a/application/src/main/scala/com/azavea/franklin/datamodel/BulkExtent.scala
+++ b/application/src/main/scala/com/azavea/franklin/datamodel/BulkExtent.scala
@@ -2,8 +2,6 @@ package com.azavea.franklin.datamodel
 
 import com.azavea.stac4s.TwoDimBbox
 
-import geotrellis.vector.Extent
-
 import java.time.Instant
 
 final case class BulkExtent(

--- a/application/src/main/scala/com/azavea/franklin/datamodel/BulkExtent.scala
+++ b/application/src/main/scala/com/azavea/franklin/datamodel/BulkExtent.scala
@@ -1,7 +1,8 @@
 package com.azavea.franklin.datamodel
 
-import java.time.Instant
 import com.azavea.stac4s.Bbox
+
+import java.time.Instant
 
 final case class BulkExtent(
     start: Option[Instant],

--- a/application/src/test/scala/com/azavea/franklin/api/TestClient.scala
+++ b/application/src/test/scala/com/azavea/franklin/api/TestClient.scala
@@ -78,6 +78,6 @@ class TestClient[F[_]: Sync](
   def getCollectionItemResource(
       item: StacItem,
       collection: StacCollection
-  ): Resource[F, (StacItem, StacCollection)] =
-    (getItemResource(collection, item), getCollectionResource(collection)).tupled
+  ): Resource[F, (StacCollection, StacItem)] =
+    (getCollectionResource(collection), getItemResource(collection, item)).tupled
 }

--- a/application/src/test/scala/com/azavea/franklin/api/services/CollectionItemsServiceSpec.scala
+++ b/application/src/test/scala/com/azavea/franklin/api/services/CollectionItemsServiceSpec.scala
@@ -46,7 +46,7 @@ class CollectionItemsServiceSpec
   def listCollectionItemsExpectation = prop {
     (stacCollection: StacCollection, stacItem: StacItem) =>
       val listIO = testClient.getCollectionItemResource(stacItem, stacCollection) use {
-        case (_, collection) =>
+        case (collection, _) =>
           val encodedCollectionId =
             URLEncoder.encode(collection.id, StandardCharsets.UTF_8.toString)
           val request = Request[IO](
@@ -73,7 +73,7 @@ class CollectionItemsServiceSpec
   def createDeleteItemExpectation = prop { (stacCollection: StacCollection, stacItem: StacItem) =>
     val testIO: IO[Result] = testClient
       .getCollectionItemResource(stacItem, stacCollection) use {
-      case (item, collection) =>
+      case (collection, item) =>
         val encodedCollectionId = URLEncoder.encode(collection.id, StandardCharsets.UTF_8.toString)
         val request = Request[IO](
           method = Method.GET,
@@ -85,10 +85,7 @@ class CollectionItemsServiceSpec
           decodedCollection <- OptionT.liftF(resp.as[StacCollection])
         } yield {
           val collectionBbox = decodedCollection.extent.spatial.bbox.head
-          val testA: Result = collectionBbox
-            .union(collection.extent.spatial.bbox.head) must beTypedEqualTo(collectionBbox)
-          val testB: Result = collectionBbox.union(item.bbox) must beTypedEqualTo(collectionBbox)
-          testA and testB
+          (collectionBbox.union(item.bbox) must beTypedEqualTo(collectionBbox)): Result
         }).getOrElse({
           failure: Result
         })
@@ -100,7 +97,7 @@ class CollectionItemsServiceSpec
 
   def getCollectionItemExpectation = prop { (stacCollection: StacCollection, stacItem: StacItem) =>
     val fetchIO = testClient.getCollectionItemResource(stacItem, stacCollection) use {
-      case (item, collection) =>
+      case (collection, item) =>
         val encodedCollectionId =
           URLEncoder.encode(collection.id, StandardCharsets.UTF_8.toString)
         val encodedItemId = URLEncoder.encode(item.id, StandardCharsets.UTF_8.toString)
@@ -129,7 +126,7 @@ class CollectionItemsServiceSpec
   def updateItemExpectation = prop {
     (stacCollection: StacCollection, stacItem: StacItem, update: StacItem) =>
       val updateIO = testClient.getCollectionItemResource(stacItem, stacCollection) use {
-        case (item, collection) =>
+        case (collection, item) =>
           val encodedCollectionId =
             URLEncoder.encode(collection.id, StandardCharsets.UTF_8.toString)
           val encodedItemId = URLEncoder.encode(item.id, StandardCharsets.UTF_8.toString)
@@ -160,7 +157,7 @@ class CollectionItemsServiceSpec
 
   def patchItemExpectation = prop { (stacCollection: StacCollection, stacItem: StacItem) =>
     val updateIO = testClient.getCollectionItemResource(stacItem, stacCollection) use {
-      case (item, collection) =>
+      case (collection, item) =>
         val encodedCollectionId =
           URLEncoder.encode(collection.id, StandardCharsets.UTF_8.toString)
         val encodedItemId = URLEncoder.encode(item.id, StandardCharsets.UTF_8.toString)

--- a/application/src/test/scala/com/azavea/franklin/api/services/SearchServiceSpec.scala
+++ b/application/src/test/scala/com/azavea/franklin/api/services/SearchServiceSpec.scala
@@ -95,7 +95,7 @@ class SearchServiceSpec
   def findItemWhenExpected = prop { (stacItem: StacItem, stacCollection: StacCollection) =>
     val resource = testClient.getCollectionItemResource(stacItem, stacCollection)
     val requestIO = resource.use {
-      case (item, collection) =>
+      case (collection, item) =>
         val inclusiveParams =
           FiltersFor.inclusiveFilters(collection, item)
         val request =

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -35,7 +35,7 @@ object Versions {
   val Slf4jVersion            = "1.7.30"
   val Specs2Version           = "4.10.6"
   val SpireVersion            = "0.13.0"
-  val Stac4SVersion           = "0.1.1"
+  val Stac4SVersion           = "0.1.1-2-gdaff095-SNAPSHOT"
   val SttpClientVersion       = "2.2.9"
   val SttpShared              = "1.1.0"
   val SttpModelVersion        = "1.4.0"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -35,7 +35,7 @@ object Versions {
   val Slf4jVersion            = "1.7.30"
   val Specs2Version           = "4.10.6"
   val SpireVersion            = "0.13.0"
-  val Stac4SVersion           = "0.1.1-2-gdaff095-SNAPSHOT"
+  val Stac4SVersion           = "0.1.1"
   val SttpClientVersion       = "2.2.9"
   val SttpShared              = "1.1.0"
   val SttpModelVersion        = "1.4.0"


### PR DESCRIPTION
## Overview

This PR makes it so that when you add an item via the POST endpoint or add lots of items with the bulk importer, the collection extent it grown to include any new geometric area that's covered.

It's wip because on update / delete you have to check all the existing items to calculate the new extent, and I'd like to do that in
the background rather than in a way that blocks the response, in case it's costly. 

### Checklist

- [x] New tests have been added or existing tests have been modified

### Notes

I'm scoping this down to just _expanding_ extends when items are added or changed. The reason for this is that in those two cases, I always have enough information from the new items to calculate the new extent. If I want to shrink an extent, then I need to know the spatial and temporal extent of every item in this collection in the database to figure out the new extent. I don't know how costly that aggregation will be, so I'd like to do it in the background to protect us from large updates, but at the same time I'm not certain that doing it in the background will be sufficient since the transaction will acquire a write lock against the collection row.

### Testing Instructions

This is pretty hard to test unless you have data handy already, but here's the testing flow I did, and which I'm happy to demo as well:

- save off an existing collection into a new json file
- update the id to `dummy-collection`
- post it to collections
- grab a nice item from the prior collection and save it off to a new json file
- edit its geometry and datetime to be outside the current spatial and temporal extent of the new collection you just created
- post it to `/collections/dummy-collection/items`
- fetch your collection again -- the extent should now include the time and bbox of the item you just posted 🎉

Closes #615
