### PR TITLE
Performance -- separately index datetime fields, count item results in parallel

### DIFF
--- a/application/src/main/resources/migrations/V8__index_item_times.sql
+++ b/application/src/main/resources/migrations/V8__index_item_times.sql
@@ -17,6 +17,10 @@ ALTER TABLE
 ADD
     COLUMN datetime timestamp with time zone;
 
+-- in a testing setting, this temp table hasn't disappeared
+-- by the time migration 8 needs to be applied 🤦🏻‍♂️
+DROP TABLE IF EXISTS collection_items_tmp;
+
 CREATE TEMP TABLE collection_items_tmp AS (
     SELECT
         id,

--- a/application/src/main/resources/migrations/V8__index_item_times.sql
+++ b/application/src/main/resources/migrations/V8__index_item_times.sql
@@ -61,3 +61,7 @@ INSERT INTO
         from
             collection_items_tmp
     );
+
+-- this cleanup will mean that future migrations won't have to drop
+-- the table twice to be applicable in test settings, just once at the end
+DROP TABLE IF EXISTS collection_items_tmp;

--- a/application/src/main/resources/migrations/V8__index_item_times.sql
+++ b/application/src/main/resources/migrations/V8__index_item_times.sql
@@ -1,0 +1,59 @@
+-- this index was referring to the top-level item object, which doesn't
+-- help with searches into the item's `properties` field
+DROP INDEX IF EXISTS collection_item_json_idx;
+
+ALTER TABLE
+    collection_items
+ADD
+    COLUMN start_datetime timestamp with time zone;
+
+ALTER TABLE
+    collection_items
+ADD
+    COLUMN end_datetime timestamp with time zone;
+
+ALTER TABLE
+    collection_items
+ADD
+    COLUMN datetime timestamp with time zone;
+
+CREATE TEMP TABLE collection_items_tmp AS (
+    SELECT
+        id,
+        geom,
+        item,
+        serial_id,
+        created_at,
+        collection,
+        (
+            (item -> 'properties' ->> 'start_datetime') :: timestamp with time zone
+        ) start_datetime,
+        (
+            (item -> 'properties' ->> 'end_datetime') :: timestamp with time zone
+        ) end_datetime,
+        (
+            (item -> 'properties' ->> 'datetime') :: timestamp with time zone
+        ) datetime
+    FROM
+        collection_items
+);
+
+TRUNCATE TABLE collection_items;
+
+-- this index replaces the former collection_item_json_idx but indexing into properties instead of
+-- indexing the top-level of the item
+CREATE INDEX IF NOT EXISTS collection_items_properties_idx ON collection_items USING gin ((item -> 'properties'));
+
+CREATE INDEX IF NOT EXISTS collection_items_start_datetime_idx ON collection_items (start_datetime);
+
+CREATE INDEX IF NOT EXISTS collection_items_end_datetime_idx ON collection_items (end_datetime);
+
+CREATE INDEX IF NOT EXISTS collection_items_datetime_idx ON collection_items (datetime);
+
+INSERT INTO
+    collection_items (
+        select
+            *
+        from
+            collection_items_tmp
+    );

--- a/application/src/main/scala/com/azavea/franklin/database/Filterables.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/Filterables.scala
@@ -18,13 +18,11 @@ trait FilterHelpers {
     def toFilterFragment: Option[Fragment] = {
       temporalExtent.value match {
         case Some(start) :: Some(end) :: _ =>
-          Some(
-            fr"(item #>> '{properties, datetime}') :: TIMESTAMPTZ >= $start AND (item #>> '{properties, datetime}') :: TIMESTAMPTZ <= $end"
-          )
+          Some(fr"(datetime >= $start AND datetime <= $end)")
         case Some(start) :: _ =>
-          Some(fr"(item #>> '{properties, datetime}') :: TIMESTAMPTZ >= $start")
+          Some(fr"datetime >= $start")
         case _ :: Some(end) :: _ =>
-          Some(fr"(item #>> '{properties, datetime}') :: TIMESTAMPTZ <= $end")
+          Some(fr"datetime <= $end")
         case _ => None
       }
     }

--- a/application/src/main/scala/com/azavea/franklin/database/Filterables.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/Filterables.scala
@@ -9,8 +9,8 @@ import doobie.postgres.circe.jsonb.implicits._
 import doobie.refined.implicits._
 import doobie.{Query => _, _}
 import geotrellis.vector.Projected
-import io.circe.syntax._
 import io.circe.Json
+import io.circe.syntax._
 
 trait FilterHelpers {
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,4 +7,4 @@ addSbtPlugin("ch.epfl.scala"             % "sbt-scalafix"              % "0.9.26
 addSbtPlugin("com.eed3si9n"              % "sbt-assembly"              % "0.14.9")
 addSbtPlugin("com.github.cb372"          % "sbt-explicit-dependencies" % "0.2.16")
 addSbtPlugin("org.jmotor.sbt"            % "sbt-dependency-updates"    % "1.2.2")
-addSbtPlugin("org.scalameta"             % "sbt-mdoc"                  % "2.2.18")
+addSbtPlugin("org.scalameta"             % "sbt-mdoc"                  % "2.2.14")


### PR DESCRIPTION
## Overview

This PR makes three performance-related improvements:

- it adds a migration to separately index time fields, rather than relying on the jsonb index for them
- it changes equality checks using `query: {...}` searches to use the `@>` jsonb operator, which lets postgres know that it should use the jsonb gin index that's modified in the migration in this PR to actually point to the right field (🤦🏻‍♂️). This is still not fast :tm: when it's the only filter, but in the presence of time filters as well, it results in dramatic speedups
- it counts items coming back from searches in parallel with the list, since we only need the `count` to assemble the context object

### Checklist

- ~New tests have been added or existing tests have been modified~ these behaviors are all tested in existing API tests

### Testing Instructions

- CI is sufficient for "didn't break anything" since this whole zone has tests
- I'll post some query json docs that you can POST to `/search` against `master` and this branch, or, since I have an unusually large local Franklin, I can demo that part

Closes #629
