### PR TITLE
Update postgres container to dev version

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -56,7 +56,7 @@ docker run -d -p 5432:5432 \
   -e POSTGRES_PASSWORD=franklinsecret \
   -e POSTGRES_USER=benjamin \
   -e POSTGRES_DB=franklin \
-  quay.io/azavea/postgis:2.5-postgres11.4-slim
+  quay.io/azavea/postgis:3-postgres12.2-slim
 ```
 
 This starts a database (`franklin-database`) in the background. If you want to see that it is still running you can use the `docker ps` command. If you want to stop it at some point you can use the command `docker stop franklin-database` and that will stop the container.


### PR DESCRIPTION
## Overview

In dev we use postgres 12 + postgis 3.0. In docs, we were pointing to postgres 11 + postgis 2.5. Postgres 12 + postgis 3 has support in [RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.FeatureSupport.Extensions.12x) and [Google Cloud SQL](https://cloud.google.com/sql/docs/postgres/extensions#postgis). Azure lags behind a bit (seems only to have Postgres support up to 11? or [docs](https://docs.microsoft.com/en-us/azure/postgresql/concepts-extensions) are behind), which is _probably bad_ for Azure deployments (we use [`ST_TileEnvelope`](https://github.com/azavea/franklin/blob/master/application/src/main/scala/com/azavea/franklin/database/StacCollectionDao.scala#L123-L128), which is [only available beginning in postgis 3](https://postgis.net/docs/ST_TileEnvelope.html)). This is something to keep in mind if someone asks us about Azure deployments, but we'll cross that bridge when we come to it.

### Checklist

- ~New tests have been added or existing tests have been modified~

Closes #659
