### PR TITLE
Restore accidentally deleted routes

### DIFF
--- a/application/src/main/scala/com/azavea/franklin/api/endpoints/LandingPageEndpoints.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/endpoints/LandingPageEndpoints.scala
@@ -1,0 +1,47 @@
+package com.azavea.franklin.api.endpoints
+
+import cats.effect._
+import com.azavea.franklin.api._
+import com.azavea.franklin.datamodel._
+import fs2.{Stream => FS2Stream}
+import io.circe._
+import sttp.capabilities.fs2.Fs2Streams
+import sttp.tapir._
+import sttp.tapir._
+import sttp.tapir.codec.refined._
+import sttp.tapir.generic.auto._
+import sttp.tapir.json.circe._
+
+case class AcceptHeader(v: Option[String]) {
+  private val mediaTypeOption = v.map(_.split(","))
+
+  lazy val acceptJson = mediaTypeOption match {
+    case Some(acceptStrings) => acceptStrings.contains("application/json")
+    case _                   => true
+  }
+}
+
+class LandingPageEndpoints[F[_]: Sync] {
+
+  val base = endpoint.in("")
+
+  val landingPageEndpoint: Endpoint[Unit, Unit, LandingPage, Fs2Streams[F]] =
+    base.get
+      .out(
+        jsonBody[LandingPage]
+      )
+      .description("STAC Service Provided via [franklin](https://github.com/azavea/franklin)")
+      .name("landingPage")
+
+  val conformanceEndpoint: Endpoint[Unit, Unit, Conformance, Fs2Streams[F]] =
+    endpoint.get
+      .in("conformance")
+      .out(jsonBody[Conformance])
+      .description(
+        "A list of all conformance classes specified in a standard that the server conforms to"
+      )
+      .name("conformance")
+
+  val endpoints = List(conformanceEndpoint, landingPageEndpoint)
+
+}

--- a/application/src/main/scala/com/azavea/franklin/api/schemas/package.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/schemas/package.scala
@@ -11,6 +11,7 @@ import com.azavea.stac4s._
 import com.azavea.stac4s.types.TemporalExtent
 import eu.timepit.refined.types.string.NonEmptyString
 import geotrellis.vector.Geometry
+import io.circe.syntax._
 import io.circe.{Encoder, Json}
 import sttp.tapir.Codec.PlainCodec
 import sttp.tapir.json.circe._
@@ -87,5 +88,8 @@ package object schemas {
 
   implicit val codecPaginationToken: Codec.PlainCodec[PaginationToken] =
     Codec.string.mapDecode(PaginationToken.decPaginationToken)(PaginationToken.encPaginationToken)
+
+  implicit val schemaForStacLink: Schema[StacLinkType] =
+    Schema.schemaForString.map(s => s.asJson.as[StacLinkType].toOption)(_.repr)
 
 }

--- a/application/src/main/scala/com/azavea/franklin/api/services/LandingPageService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/LandingPageService.scala
@@ -1,0 +1,92 @@
+package com.azavea.franklin.api.services
+
+import cats._
+import cats.effect._
+import cats.syntax.all._
+import com.azavea.franklin
+import com.azavea.franklin.api._
+import com.azavea.franklin.api.commands.ApiConfig
+import com.azavea.franklin.api.endpoints._
+import com.azavea.franklin.api.implicits._
+import com.azavea.franklin.database._
+import com.azavea.franklin.datamodel.{LandingPage, Link, Conformance => FranklinConformance}
+import com.azavea.stac4s.StacLinkType
+import com.azavea.stac4s._
+import doobie._
+import doobie.implicits._
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.string.NonEmptyString
+import io.circe.syntax._
+import org.http4s._
+import org.http4s.dsl.Http4sDsl
+import sttp.tapir.server.http4s._
+
+class LandingPageService[F[_]: Concurrent](apiConfig: ApiConfig)(
+    implicit contextShift: ContextShift[F],
+    timer: Timer[F],
+    serverOptions: Http4sServerOptions[F]
+) extends Http4sDsl[F] {
+
+  val links = List(
+    Link(
+      apiConfig.apiHost,
+      StacLinkType.Self,
+      Some(`application/json`),
+      Some("Franklin Powered Catalog")
+    ),
+    Link(
+      apiConfig.apiHost + "/open-api/spec.yaml",
+      StacLinkType.ServiceDesc,
+      Some(VendorMediaType("application/vnd.oai.openapi+json;version=3.0")),
+      Some("Open API 3 Documentation")
+    ),
+    Link(
+      apiConfig.apiHost + "/conformance",
+      StacLinkType.Conformance,
+      Some(`application/json`),
+      Some("Conformance")
+    ),
+    Link(
+      apiConfig.apiHost + "/collections",
+      StacLinkType.Data,
+      Some(`application/json`),
+      Some("Collections Listing")
+    ),
+    Link(
+      apiConfig.apiHost + "/search",
+      StacLinkType.Data,
+      Some(`application/geo+json`),
+      Some("STAC Search API")
+    )
+  )
+
+  def conformancePage: F[Either[Unit, FranklinConformance]] = {
+    val uriList: List[NonEmptyString] = List(
+      "http://www.opengis.net/spec/ogcapi-features-1/1.0/req/core",
+      "http://www.opengis.net/spec/ogcapi-features-1/1.0/req/oas30",
+      "http://www.opengis.net/spec/ogcapi-features-1/1.0/req/geojson"
+    )
+    val conformance = FranklinConformance(uriList)
+
+    Applicative[F].pure(Either.right[Unit, FranklinConformance](conformance))
+  }
+
+  def landingPage: F[Either[Unit, LandingPage]] = {
+    val title: NonEmptyString = "Welcome to Franklin"
+    val description: NonEmptyString =
+      "An OGC API - Features, Tiles, and STAC Server"
+    val landingPage = LandingPage(title, description, links)
+
+    Applicative[F].pure(Either.right[Unit, LandingPage](landingPage))
+
+  }
+
+  val endpoints = new LandingPageEndpoints[F]()
+
+  val routesList = List(
+    Http4sServerInterpreter.toRoutes(endpoints.conformanceEndpoint)(_ => conformancePage),
+    Http4sServerInterpreter.toRoutes(endpoints.landingPageEndpoint)(_ => landingPage)
+  )
+
+  val routes: HttpRoutes[F] = routesList.foldK
+}

--- a/application/src/main/scala/com/azavea/franklin/datamodel/LandingPage.scala
+++ b/application/src/main/scala/com/azavea/franklin/datamodel/LandingPage.scala
@@ -1,0 +1,18 @@
+package com.azavea.franklin.datamodel
+
+import com.azavea.stac4s.StacLinkType
+import eu.timepit.refined.types.string.NonEmptyString
+import io.circe.generic.semiauto._
+
+case class LandingPage(title: NonEmptyString, description: NonEmptyString, links: List[Link]) {
+
+  lazy val dataLinks = links.filter(_.rel == StacLinkType.Data)
+
+  lazy val docLinks =
+    links.filter(l => (l.rel == StacLinkType.ServiceDesc || l.rel == StacLinkType.Conformance))
+}
+
+object LandingPage {
+  implicit val landingPageEncoder = deriveEncoder[LandingPage]
+  implicit val landingPageDecoder = deriveDecoder[LandingPage]
+}

--- a/application/src/main/scala/com/azavea/franklin/datamodel/Link.scala
+++ b/application/src/main/scala/com/azavea/franklin/datamodel/Link.scala
@@ -4,6 +4,8 @@ import com.azavea.stac4s.{StacLinkType, StacMediaType}
 import eu.timepit.refined.types.string.NonEmptyString
 import io.circe.Encoder
 import io.circe.generic.semiauto._
+import sttp.tapir.Schema
+import sttp.tapir.codec.refined._
 
 case class Link(
     href: NonEmptyString,

--- a/build.sbt
+++ b/build.sbt
@@ -83,6 +83,7 @@ lazy val applicationDependencies = Seq(
   "ch.qos.logback"               % "logback-classic"                 % Versions.LogbackVersion,
   "com.amazonaws"                % "aws-java-sdk-core"               % Versions.AWSVersion,
   "com.amazonaws"                % "aws-java-sdk-s3"                 % Versions.AWSVersion,
+  "co.fs2"                       %% "fs2-core"                       % Versions.Fs2Version,
   "com.azavea.geotrellis"        %% "geotrellis-server-core"         % Versions.GeotrellisServerVersion,
   "com.azavea.geotrellis"        %% "maml-jvm"                       % Versions.MamlVersion,
   "com.azavea.stac4s"            %% "core"                           % Versions.Stac4SVersion,


### PR DESCRIPTION
## Overview

This PR restores the conformance and landing page routes that I accidentally deleted in #381.

### Checklist

- ~New tests have been added or existing tests have been modified~
someday we'll have a STAC API conformance suite... someday

### Testing Instructions

- hit :9090 and :9090/conformance with the server running

Closes #611 