### PR TITLE
Make landing page match current spec and other 1.0.0-rc.2 fixes

### DIFF
--- a/application/src/main/resources/migrations/V11__bump_stac_versions.sql
+++ b/application/src/main/resources/migrations/V11__bump_stac_versions.sql
@@ -1,0 +1,9 @@
+UPDATE
+    collections
+SET
+    collection = collection || '{"stac_version": "1.0.0-rc.2"}';
+
+UPDATE
+    collection_items
+SET
+    item = item || '{"stac_version": "1.0.0-rc.2"}';

--- a/application/src/main/scala/com/azavea/franklin/api/Server.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/Server.scala
@@ -107,7 +107,7 @@ $$$$
         docs      = allEndpoints.toOpenAPI("Franklin", "0.0.1")
         docRoutes = new SwaggerHttp4s(docs.toYaml, "open-api", "spec.yaml").routes[IO]
         searchRoutes = new SearchService[IO](
-          apiConfig.apiHost,
+          apiConfig,
           apiConfig.defaultLimit,
           apiConfig.enableTiles,
           xa

--- a/application/src/main/scala/com/azavea/franklin/api/Server.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/Server.scala
@@ -113,8 +113,8 @@ $$$$
           xa
         ).routes
         tileRoutes = new TileService[IO](apiConfig.apiHost, apiConfig.enableTiles, xa).routes
-        itemExtensions       <- Resource.liftF { itemExtensionsRef[IO] }
-        collectionExtensions <- Resource.liftF { collectionExtensionsRef[IO] }
+        itemExtensions       <- Resource.eval { itemExtensionsRef[IO] }
+        collectionExtensions <- Resource.eval { collectionExtensionsRef[IO] }
         collectionRoutes = new CollectionsService[IO](xa, apiConfig, collectionExtensions).routes <+> new CollectionItemsService[
           IO
         ](

--- a/application/src/main/scala/com/azavea/franklin/api/implicits/package.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/implicits/package.scala
@@ -53,6 +53,10 @@ package object implicits {
       (item.copy(links = updatedLinks))
     }
 
+    def addRootLink(link: StacLink): StacItem =
+      item.copy(
+        links = item.links.filter(_.rel != StacLinkType.StacRoot) :+ link
+      )
   }
 
   implicit class UpdatedStacLink(link: StacLink) {

--- a/application/src/main/scala/com/azavea/franklin/api/services/CollectionItemsService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/CollectionItemsService.scala
@@ -44,7 +44,8 @@ import java.nio.charset.StandardCharsets
 class CollectionItemsService[F[_]: Concurrent](
     xa: Transactor[F],
     apiConfig: ApiConfig,
-    itemExtensionsRef: ExtensionRef[F, StacItem]
+    itemExtensionsRef: ExtensionRef[F, StacItem],
+    rootLink: StacLink
 )(
     implicit contextShift: ContextShift[F],
     timer: Timer[F],
@@ -82,7 +83,7 @@ class CollectionItemsService[F[_]: Concurrent](
         case _ => items
       }
       val withValidatedLinks =
-        updatedItems.zip(validators) map { case (item, f) => f(item) }
+        updatedItems.zip(validators) map { case (item, f) => f(item.addRootLink(rootLink)) }
       val nextLink: Option[StacLink] = paginationToken.flatten map { token =>
         val lim = limit getOrElse defaultLimit
         StacLink(
@@ -121,7 +122,7 @@ class CollectionItemsService[F[_]: Concurrent](
             val updatedItem = (if (enableTiles) { item.addTilesLink(apiHost, collectionId, itemId) }
                                else { item })
             (
-              validator(updatedItem).updateLinksWithHost(apiConfig).asJson,
+              validator(updatedItem).addRootLink(rootLink).updateLinksWithHost(apiConfig).asJson,
               item.##.toString
             )
         },
@@ -196,7 +197,9 @@ class CollectionItemsService[F[_]: Concurrent](
           }
         case None =>
           val withParent =
-            item.copy(links = fallbackCollectionLink +: item.links, collection = Some(collectionId))
+            item
+              .copy(links = fallbackCollectionLink +: item.links, collection = Some(collectionId))
+              .addRootLink(rootLink)
           StacItemDao.insertStacItem(withParent).transact(xa) map {
             case Right(inserted) =>
               val validated = validator(inserted)
@@ -232,7 +235,7 @@ class CollectionItemsService[F[_]: Concurrent](
         case Left(_) =>
           Left(ValidationError(s"Update of $itemId not possible with value passed"))
         case Right(item) =>
-          Right((validator(item).asJson, item.##.toString))
+          Right((validator(item).addRootLink(rootLink).asJson, item.##.toString))
       }
     }
   }
@@ -314,7 +317,7 @@ class CollectionItemsService[F[_]: Concurrent](
           .pure[F]
       case Some(Right(updated)) =>
         makeItemValidator(updated.stacExtensions, itemExtensionsRef) map { validator =>
-          Either.right((validator(updated).asJson, updated.##.toString))
+          Either.right((validator(updated).addRootLink(rootLink).asJson, updated.##.toString))
         }
 
     }

--- a/application/src/main/scala/com/azavea/franklin/api/services/LandingPageService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/LandingPageService.scala
@@ -54,7 +54,7 @@ class LandingPageService[F[_]: Concurrent](apiConfig: ApiConfig)(
     ),
     Link(
       apiConfig.apiHost + "/search",
-      StacLinkType.Data,
+      StacLinkType.VendorLinkType("search"),
       Some(`application/geo+json`),
       Some("STAC Search API")
     )

--- a/application/src/main/scala/com/azavea/franklin/api/services/LandingPageService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/LandingPageService.scala
@@ -60,13 +60,14 @@ class LandingPageService[F[_]: Concurrent](apiConfig: ApiConfig)(
     )
   )
 
+  private val conformances: List[NonEmptyString] = List(
+    "http://www.opengis.net/spec/ogcapi-features-1/1.0/req/core",
+    "http://www.opengis.net/spec/ogcapi-features-1/1.0/req/oas30",
+    "http://www.opengis.net/spec/ogcapi-features-1/1.0/req/geojson"
+  )
+
   def conformancePage: F[Either[Unit, FranklinConformance]] = {
-    val uriList: List[NonEmptyString] = List(
-      "http://www.opengis.net/spec/ogcapi-features-1/1.0/req/core",
-      "http://www.opengis.net/spec/ogcapi-features-1/1.0/req/oas30",
-      "http://www.opengis.net/spec/ogcapi-features-1/1.0/req/geojson"
-    )
-    val conformance = FranklinConformance(uriList)
+    val conformance = FranklinConformance(conformances)
 
     Applicative[F].pure(Either.right[Unit, FranklinConformance](conformance))
   }
@@ -75,7 +76,15 @@ class LandingPageService[F[_]: Concurrent](apiConfig: ApiConfig)(
     val title: NonEmptyString = "Welcome to Franklin"
     val description: NonEmptyString =
       "An OGC API - Features, Tiles, and STAC Server"
-    val landingPage = LandingPage(title, description, links)
+    val landingPage = LandingPage(
+      "1.0.0-rc.2",
+      Nil,
+      Some(title),
+      "Franklin STAC API",
+      description,
+      links,
+      conformances
+    )
 
     Applicative[F].pure(Either.right[Unit, LandingPage](landingPage))
 

--- a/application/src/main/scala/com/azavea/franklin/api/services/SearchService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/SearchService.scala
@@ -8,6 +8,7 @@ import com.azavea.franklin.database.{SearchFilters, StacItemDao}
 import com.azavea.franklin.datamodel.{Context, SearchMethod, StacSearchCollection}
 import doobie.implicits._
 import doobie.util.transactor.Transactor
+import eu.timepit.refined.auto._
 import eu.timepit.refined.types.numeric.NonNegInt
 import eu.timepit.refined.types.string.NonEmptyString
 import io.circe._
@@ -15,9 +16,10 @@ import io.circe.syntax._
 import org.http4s._
 import org.http4s.dsl.Http4sDsl
 import sttp.tapir.server.http4s._
+import com.azavea.franklin.api.commands.ApiConfig
 
 class SearchService[F[_]: Concurrent](
-    apiHost: NonEmptyString,
+    apiConfig: ApiConfig,
     defaultLimit: NonNegInt,
     enableTiles: Boolean,
     xa: Transactor[F]
@@ -36,7 +38,7 @@ class SearchService[F[_]: Concurrent](
         (StacItemDao.query
           .filter(searchFilters)
           .list(limit.value) flatMap { items =>
-          StacItemDao.getSearchLinks(items, limit, searchFilters, apiHost, searchMethod) map {
+          StacItemDao.getSearchLinks(items, limit, searchFilters, apiConfig.apiHost, searchMethod) map {
             (items, _)
           }
         }).transact(xa)
@@ -46,11 +48,13 @@ class SearchService[F[_]: Concurrent](
       }
       ((items, links), count) <- (itemsFib, countFib).tupled.join
     } yield {
-      val searchResult = StacSearchCollection(Context(items.length, count), items, links)
+      val withApiHost  = items map { _.updateLinksWithHost(apiConfig) }
+      val searchResult = StacSearchCollection(Context(items.length, count), withApiHost, links)
       val updatedFeatures = searchResult.features.map { item =>
         (item.collection, enableTiles) match {
-          case (Some(collectionId), true) => item.addTilesLink(apiHost.value, collectionId, item.id)
-          case _                          => item
+          case (Some(collectionId), true) =>
+            item.addTilesLink(apiConfig.apiHost, collectionId, item.id)
+          case _ => item
         }
       }
       Either.right(searchResult.copy(features = updatedFeatures).asJson)

--- a/application/src/main/scala/com/azavea/franklin/crawler/CatalogStacImport.scala
+++ b/application/src/main/scala/com/azavea/franklin/crawler/CatalogStacImport.scala
@@ -14,6 +14,7 @@ import com.azavea.stac4s.syntax._
 import doobie.ConnectionIO
 import doobie.implicits._
 import doobie.util.transactor.Transactor
+import eu.timepit.refined.auto._
 import geotrellis.vector.io.json.Implicits._
 import geotrellis.vector.io.json._
 import geotrellis.vector.{Feature, Geometry}
@@ -129,6 +130,7 @@ class CatalogStacImport(val catalogRoot: String) {
                       None
                     )
                   val labelCollection = StacCollection(
+                    "Collection",
                     "1.0.0-rc2",
                     Nil,
                     s"${forItem.id}-labels-${idx + 1}",

--- a/application/src/main/scala/com/azavea/franklin/datamodel/LandingPage.scala
+++ b/application/src/main/scala/com/azavea/franklin/datamodel/LandingPage.scala
@@ -2,9 +2,19 @@ package com.azavea.franklin.datamodel
 
 import com.azavea.stac4s.StacLinkType
 import eu.timepit.refined.types.string.NonEmptyString
+import io.circe.Encoder
 import io.circe.generic.semiauto._
+import com.azavea.stac4s.StacLink
 
-case class LandingPage(title: NonEmptyString, description: NonEmptyString, links: List[Link]) {
+case class LandingPage(
+    stacVersion: String,
+    stacExtensions: List[String],
+    title: Option[String],
+    id: NonEmptyString,
+    description: NonEmptyString,
+    links: List[Link],
+    conformsTo: List[NonEmptyString]
+) {
 
   lazy val dataLinks = links.filter(_.rel == StacLinkType.Data)
 
@@ -13,6 +23,27 @@ case class LandingPage(title: NonEmptyString, description: NonEmptyString, links
 }
 
 object LandingPage {
-  implicit val landingPageEncoder = deriveEncoder[LandingPage]
+
+  implicit val landingPageEncoder: Encoder[LandingPage] = Encoder.forProduct8(
+    "type",
+    "stac_version",
+    "stac_extensions",
+    "title",
+    "id",
+    "description",
+    "links",
+    "conformsTo"
+  )(landingPage =>
+    (
+      "Catalog",
+      landingPage.stacVersion,
+      landingPage.stacExtensions,
+      landingPage.title,
+      landingPage.id,
+      landingPage.description,
+      landingPage.links,
+      landingPage.conformsTo
+    )
+  )
   implicit val landingPageDecoder = deriveDecoder[LandingPage]
 }

--- a/application/src/main/scala/com/azavea/franklin/datamodel/LandingPage.scala
+++ b/application/src/main/scala/com/azavea/franklin/datamodel/LandingPage.scala
@@ -1,10 +1,10 @@
 package com.azavea.franklin.datamodel
 
+import com.azavea.stac4s.StacLink
 import com.azavea.stac4s.StacLinkType
 import eu.timepit.refined.types.string.NonEmptyString
 import io.circe.Encoder
 import io.circe.generic.semiauto._
-import com.azavea.stac4s.StacLink
 
 case class LandingPage(
     stacVersion: String,

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -36,7 +36,7 @@ object Versions {
   val Slf4jVersion            = "1.7.30"
   val Specs2Version           = "4.11.0"
   val SpireVersion            = "0.13.0"
-  val Stac4SVersion           = "0.2.1"
+  val Stac4SVersion           = "0.2.2"
   val SttpClientVersion       = "2.2.9"
   val SttpShared              = "1.1.0"
   val SttpModelVersion        = "1.4.5"


### PR DESCRIPTION
## Overview

This PR makes it so that the LandingPage is a catalog with a conformsTo field, as required by [the current openapi spec](https://github.com/radiantearth/stac-api-spec/blob/dev/core/openapi.yaml#L43-L47). It also adds root links to items and correects relative links in the search response and makes the rel for the search link "search".

### Checklist

- [x] New tests have been added or existing tests have been modified -- tested by making sure stacindex page from linked issue isn't mad

### Testing Instructions

- there's ongoing testing work with a few clients, so I'm going to cowboy this in to get the aviris catalog redeployed so those tests can proceed

Closes #698 
