### PR TITLE
Search uses ids, not "items"

### DIFF
--- a/application/src/main/scala/com/azavea/franklin/database/SearchFilters.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/SearchFilters.scala
@@ -52,13 +52,13 @@ object SearchFilters {
 
   implicit val searchFilterDecoder = new Decoder[SearchFilters] {
 
-    final def apply(c: HCursor): Decoder.Result[SearchFilters] =
+    def apply(c: HCursor): Decoder.Result[SearchFilters] =
       for {
         bbox              <- c.downField("bbox").as[Option[Bbox]]
         datetime          <- c.downField("datetime").as[Option[TemporalExtent]]
         intersects        <- c.downField("intersects").as[Option[Geometry]]
         collectionsOption <- c.downField("collections").as[Option[List[String]]]
-        itemsOption       <- c.downField("items").as[Option[List[String]]]
+        itemsOption       <- c.downField("ids").as[Option[List[String]]]
         limit             <- c.downField("limit").as[Option[NonNegInt]]
         query             <- c.get[Option[Map[String, List[Query]]]]("query")
         paginationToken   <- c.get[Option[PaginationToken]]("next")

--- a/application/src/main/scala/com/azavea/franklin/database/SearchFilters.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/SearchFilters.scala
@@ -10,7 +10,7 @@ import geotrellis.vector.Geometry
 import geotrellis.vector.{io => _, _}
 import io.circe.generic.semiauto._
 import io.circe.refined._
-import io.circe.{Decoder, HCursor}
+import io.circe.{Decoder, Encoder, HCursor}
 
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
@@ -75,5 +75,26 @@ object SearchFilters {
         )
       }
   }
-  implicit val searchFilterEncoder = deriveEncoder[SearchFilters]
+
+  implicit val searchFilterEncoder: Encoder[SearchFilters] = Encoder.forProduct8(
+    "bbox",
+    "datetime",
+    "intersects",
+    "collections",
+    "ids",
+    "limit",
+    "query",
+    "next"
+  )(filters =>
+    (
+      filters.bbox,
+      filters.datetime,
+      filters.intersects,
+      filters.collections,
+      filters.items,
+      filters.limit,
+      filters.query,
+      filters.next
+    )
+  )
 }


### PR DESCRIPTION
## Overview

This PR corrects the decoder for search filters to grab the values from `ids`, not `items`.

### Checklist

- [x] New tests have been added or existing tests have been modified (they will be in a sec -- I'm verifying that the tests fail first)

### Testing Instructions

- search for a bogus item by id in a collection like: `echo '{"ids": ["bogus-id"], "collections": ["demo-collection"]}' | http :9090/search`
- you should not find an item
- use a real item id -- you should get your item back

Closes #707
