### PR TITLE
Defer null-including behavior to stac4s

### DIFF
--- a/application/src/main/scala/com/azavea/franklin/api/services/CollectionItemsService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/CollectionItemsService.scala
@@ -98,7 +98,7 @@ class CollectionItemsService[F[_]: Concurrent](
         withValidatedLinks.map(_.updateLinksWithHost(apiConfig)),
         nextLink.toList
       )
-      Either.right(response.asJson.deepDropNullValues)
+      Either.right(response.asJson)
     }
 
   }
@@ -125,8 +125,7 @@ class CollectionItemsService[F[_]: Concurrent](
               validator(updatedItem)
                 .addRootLink(rootLink)
                 .updateLinksWithHost(apiConfig)
-                .asJson
-                .deepDropNullValues,
+                .asJson,
               item.##.toString
             )
         },
@@ -150,7 +149,7 @@ class CollectionItemsService[F[_]: Concurrent](
           Either.fromOption(
             TileInfo
               .fromStacItem(apiHost, collectionId, item)
-              .map(info => (info.asJson.deepDropNullValues, info.##.toString)),
+              .map(info => (info.asJson, info.##.toString)),
             NF(
               s"Unable to construct tile info object for item $itemId in collection $collectionId. Is there at least one COG asset?"
             )
@@ -185,7 +184,7 @@ class CollectionItemsService[F[_]: Concurrent](
             StacItemDao.insertStacItem(withParent).transact(xa) map {
               case Right(inserted) =>
                 val validated = validator(inserted)
-                Right((validated.asJson.deepDropNullValues, validated.##.toString))
+                Right((validated.asJson, validated.##.toString))
               case Left(StacItemDao.InvalidTimeForPeriod) =>
                 Left(ValidationError(StacItemDao.InvalidTimeForPeriod.msg))
               // this fall through covers the only other failure mode for item creation
@@ -207,7 +206,7 @@ class CollectionItemsService[F[_]: Concurrent](
           StacItemDao.insertStacItem(withParent).transact(xa) map {
             case Right(inserted) =>
               val validated = validator(inserted)
-              Right((validated.asJson.deepDropNullValues, validated.##.toString))
+              Right((validated.asJson, validated.##.toString))
             case Left(StacItemDao.InvalidTimeForPeriod) =>
               Left(ValidationError(StacItemDao.InvalidTimeForPeriod.msg))
             // this fall through covers the only other failure mode for item creation
@@ -239,7 +238,7 @@ class CollectionItemsService[F[_]: Concurrent](
         case Left(_) =>
           Left(ValidationError(s"Update of $itemId not possible with value passed"))
         case Right(item) =>
-          Right((validator(item).addRootLink(rootLink).asJson.deepDropNullValues, item.##.toString))
+          Right((validator(item).addRootLink(rootLink).asJson, item.##.toString))
       }
     }
   }
@@ -323,7 +322,7 @@ class CollectionItemsService[F[_]: Concurrent](
         makeItemValidator(updated.stacExtensions, itemExtensionsRef) map { validator =>
           Either.right(
             (
-              validator(updated).addRootLink(rootLink).asJson.deepDropNullValues,
+              validator(updated).addRootLink(rootLink).asJson,
               updated.##.toString
             )
           )

--- a/application/src/main/scala/com/azavea/franklin/api/services/CollectionsService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/CollectionsService.scala
@@ -52,7 +52,7 @@ class CollectionsService[F[_]: Concurrent](
         _.updateLinksWithHost(apiConfig)
       }
       val validated = validators.zip(updated).map { case (f, v) => f(v) }
-      Either.right(CollectionsResponse(validated).asJson.deepDropNullValues)
+      Either.right(CollectionsResponse(validated).asJson.dropNullValues)
     }
 
   }
@@ -72,7 +72,7 @@ class CollectionsService[F[_]: Concurrent](
           case (collection, validator) =>
             validator(
               collection.maybeAddTilesLink(enableTiles, apiHost).updateLinksWithHost(apiConfig)
-            ).asJson.deepDropNullValues
+            ).asJson.dropNullValues
         },
         NF(s"Collection $collectionId not found")
       )
@@ -89,7 +89,7 @@ class CollectionsService[F[_]: Concurrent](
       Either.fromOption(
         collectionOption.map(collection =>
           (
-            TileInfo.fromStacCollection(apiHost, collection).asJson.deepDropNullValues,
+            TileInfo.fromStacCollection(apiHost, collection).asJson,
             collection.##.toString
           )
         ),
@@ -122,7 +122,7 @@ class CollectionsService[F[_]: Concurrent](
     for {
       inserted  <- StacCollectionDao.insertStacCollection(newCollection, None).transact(xa)
       validator <- makeCollectionValidator(inserted.stacExtensions, collectionExtensionsRef)
-    } yield Right(validator(inserted).asJson.deepDropNullValues)
+    } yield Right(validator(inserted).asJson.dropNullValues)
   }
 
   def deleteCollection(rawCollectionId: String): F[Either[NF, Unit]] = {

--- a/application/src/main/scala/com/azavea/franklin/api/services/SearchService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/SearchService.scala
@@ -61,7 +61,7 @@ class SearchService[F[_]: Concurrent](
           }).addRootLink(rootLink)
         }
 
-      Either.right(searchResult.copy(features = updatedFeatures).asJson.deepDropNullValues)
+      Either.right(searchResult.copy(features = updatedFeatures).asJson)
     }
   }
 

--- a/application/src/main/scala/com/azavea/franklin/api/services/TileService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/TileService.scala
@@ -136,7 +136,7 @@ class TileService[F[_]: Concurrent: LiftIO](
     } yield {
       Either.fromOption(
         collectionO map { collection =>
-          TileJson.fromStacCollection(collection, serverHost).asJson.deepDropNullValues
+          TileJson.fromStacCollection(collection, serverHost).asJson
         },
         NF(s"Could not produce tile json for collection: $decoded")
       )

--- a/application/src/main/scala/com/azavea/franklin/database/CirceJsonbMeta.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/CirceJsonbMeta.scala
@@ -13,7 +13,7 @@ object CirceJsonbMeta {
 
   def apply[Type: TypeTag: Encoder: Decoder] = {
     val get = Get[Json].temap(_.as[Type].leftMap { _.message })
-    val put = Put[Json].tcontramap[Type](_.asJson.deepDropNullValues)
+    val put = Put[Json].tcontramap[Type](_.asJson)
     new Meta[Type](get, put)
   }
 }

--- a/application/src/main/scala/com/azavea/franklin/datamodel/StacSearchCollection.scala
+++ b/application/src/main/scala/com/azavea/franklin/datamodel/StacSearchCollection.scala
@@ -9,10 +9,11 @@ object StacSearchCollection {
   implicit val stacSearchEncoder = new Encoder[StacSearchCollection] {
 
     final def apply(a: StacSearchCollection): Json = Json.obj(
-      "type"     -> Json.fromString("FeatureCollection"),
-      "context"  -> a.context.asJson,
-      "features" -> a.features.asJson,
-      "links"    -> a.links.asJson
+      "type"         -> Json.fromString("FeatureCollection"),
+      "context"      -> a.context.asJson,
+      "features"     -> a.features.asJson,
+      "links"        -> a.links.asJson,
+      "stac_version" -> "1.0.0-rc2".asJson
     )
   }
 

--- a/application/src/test/scala/com/azavea/franklin/api/services/CollectionItemsServiceSpec.scala
+++ b/application/src/test/scala/com/azavea/franklin/api/services/CollectionItemsServiceSpec.scala
@@ -124,9 +124,9 @@ class CollectionItemsServiceSpec
 
     val result = fetchIO.unsafeRunSync.get
 
-    val resultAssetsWithoutNulls = result.assets.asJson.deepDropNullValues
+    val resultAssetsWithoutNulls = result.assets.asJson
 
-    val sourceAssetsWithoutNulls = stacItem.assets.asJson.deepDropNullValues
+    val sourceAssetsWithoutNulls = stacItem.assets.asJson
 
     // can't test properties or links without removing the validation extension fields
     // stac4s#115
@@ -166,9 +166,9 @@ class CollectionItemsServiceSpec
 
       val updated = updateIO.unsafeRunSync.get
 
-      val resultAssetsWithoutNulls = updated.assets.asJson.deepDropNullValues
+      val resultAssetsWithoutNulls = updated.assets.asJson
 
-      val sourceAssetsWithoutNulls = update.assets.asJson.deepDropNullValues
+      val sourceAssetsWithoutNulls = update.assets.asJson
 
       (updated.stacExtensions should beTypedEqualTo(update.stacExtensions)) and
         (resultAssetsWithoutNulls should beTypedEqualTo(sourceAssetsWithoutNulls)) and

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -36,7 +36,7 @@ object Versions {
   val Slf4jVersion            = "1.7.30"
   val Specs2Version           = "4.11.0"
   val SpireVersion            = "0.13.0"
-  val Stac4SVersion           = "0.2.2-2-gc768967-SNAPSHOT"
+  val Stac4SVersion           = "0.2.3"
   val SttpClientVersion       = "2.2.9"
   val SttpShared              = "1.1.0"
   val SttpModelVersion        = "1.4.5"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -36,7 +36,7 @@ object Versions {
   val Slf4jVersion            = "1.7.30"
   val Specs2Version           = "4.11.0"
   val SpireVersion            = "0.13.0"
-  val Stac4SVersion           = "0.2.2"
+  val Stac4SVersion           = "0.2.2-2-gc768967-SNAPSHOT"
   val SttpClientVersion       = "2.2.9"
   val SttpShared              = "1.1.0"
   val SttpModelVersion        = "1.4.5"


### PR DESCRIPTION
## Overview

This PR removes all the `deepDropNullValues` calls and just calls `.asJson` instead. It also upgrades stac4s to 0.2.3, which more precisely defines when `null` values should be included or not included. With this change, the landing page, collections by id, and items by id all pass stac-node-validator up to stac_extensions, which are not Franklin's or stac4s'es responsibility.

It also tosses a `stac_version` into the search response, since the dotnet validator wasn't thrilled that that was missing.

### Checklist

- ~New tests have been added or existing tests have been modified~

### Notes

My evaluation of semantic vs non-semantic nulls was in a way pretty ad hoc, but if the validator is mostly happy, then 🤷🏻‍♂️.

### Testing Instructions

- tests are fine