### PR TITLE
Render children links in collections list

### DIFF
--- a/application/src/main/scala/com/azavea/franklin/api/services/CollectionsService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/CollectionsService.scala
@@ -52,9 +52,11 @@ class CollectionsService[F[_]: Concurrent](
         _.updateLinksWithHost(apiConfig)
       }
       val validated = validators.zip(updated).map { case (f, v) => f(v) }
-      Either.right(CollectionsResponse(validated).asJson.dropNullValues)
+      val links = collections flatMap { collection =>
+        collection.links.filter(_.rel == StacLinkType.Self) map { _.copy(rel = StacLinkType.Child) }
+      }
+      Either.right(CollectionsResponse(validated, links).asJson.dropNullValues)
     }
-
   }
 
   def getCollectionUnique(rawCollectionId: String): F[Either[NF, Json]] = {

--- a/application/src/main/scala/com/azavea/franklin/datamodel/Collections.scala
+++ b/application/src/main/scala/com/azavea/franklin/datamodel/Collections.scala
@@ -1,33 +1,12 @@
 package com.azavea.franklin.datamodel
 
-import com.azavea.stac4s.StacCollection
+import com.azavea.stac4s.{StacCollection, StacLink}
 import io.circe._
 import io.circe.generic.semiauto._
 
-case class CollectionLinks(
-    href: String,
-    rel: String,
-    _type: Option[String],
-    hreflang: Option[String],
-    title: Option[String],
-    length: Option[String]
-)
-
-object CollectionLinks {
-
-  implicit val encodeCollectionLinks: Encoder[CollectionLinks] =
-    Encoder.forProduct6("href", "rel", "type", "hreflang", "title", "length")(cl =>
-      (cl.href, cl.rel, cl._type, cl.hreflang, cl.title, cl.length)
-    )
-
-  implicit val decodeCollectionLinks: Decoder[CollectionLinks] =
-    Decoder.forProduct6("href", "rel", "type", "hreflang", "title", "length")(CollectionLinks.apply)
-
-}
-
 case class CollectionsResponse(
     collections: List[StacCollection],
-    links: List[CollectionLinks] = List()
+    links: List[StacLink] = List()
 )
 
 object CollectionsResponse {

--- a/scripts/test
+++ b/scripts/test
@@ -37,8 +37,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         fi
 
         echo "Executing Scala tests"
-        echo -e "\e[32m[franklin] Execute Scalafix\e[0m"
-        ./sbt ";scalafix --check;test:scalafix --check;scalafmtCheck;test:scalafmtCheck;scalafmtSbtCheck;scapegoat;undeclaredCompileDependenciesTest;unusedCompileDependenciesTest;test"
+        ./sbt ";scalafix --check;Test/scalafix --check;scalafmtCheck;Test/scalafmtCheck;scalafmtSbtCheck;scapegoat;undeclaredCompileDependenciesTest;unusedCompileDependenciesTest;test"
 
     fi
 fi


### PR DESCRIPTION
## Overview

This PR makes it so that all the collections that come back in `/collections` are also linked to in the `links` field of the collections response. This enhances _crawlability_. It also, I think, though I haven't tested, ensures that Franklin can crawl other APIs hosted on Franklin from the `/collections` route, which might be a useful invariant to keep in mind. Thanks to @jjrom for the note.

### Checklist

- [x] New tests have been added or existing tests have been modified

### Notes

Gonna add a test that the child points to the inserted collection tomorrow

### Testing Instructions

- tests, once added