### PR TITLE
Do a much more thorough job with item times

### DIFF
--- a/application/src/main/resources/migrations/V12__update_time_fields_again.sql
+++ b/application/src/main/resources/migrations/V12__update_time_fields_again.sql
@@ -1,0 +1,16 @@
+UPDATE
+    collection_items
+SET
+    datetime = (item -> 'properties' ->> 'datetime') :: timestamp with time zone
+WHERE
+    item -> 'properties' ? 'datetime'
+    AND datetime is null;
+
+UPDATE
+    collection_items
+SET
+    start_datetime = (item -> 'properties' ->> 'start_datetime') :: timestamp with time zone,
+    end_datetime = (item -> 'properties' ->> 'end_datetime') :: timestamp with time zone
+WHERE
+    item -> 'properties' ? 'start_datetime'
+    AND start_datetime is null;

--- a/application/src/main/scala/com/azavea/franklin/crawler/CatalogStacImport.scala
+++ b/application/src/main/scala/com/azavea/franklin/crawler/CatalogStacImport.scala
@@ -153,7 +153,7 @@ class CatalogStacImport(val catalogRoot: String) {
                       )
                     ),
                     ().asJsonObject,
-                    forItem.properties,
+                    forItem.properties.asJson.asObject.getOrElse(JsonObject.empty),
                     List(parentCollectionLink, derivedFromItemLink),
                     Some(Map.empty)
                   )

--- a/application/src/main/scala/com/azavea/franklin/crawler/FeatureExtractor.scala
+++ b/application/src/main/scala/com/azavea/franklin/crawler/FeatureExtractor.scala
@@ -6,6 +6,7 @@ import com.azavea.stac4s._
 import geotrellis.vector.methods.Implicits._
 import geotrellis.vector.{Feature, Geometry}
 import io.circe.JsonObject
+import io.circe.syntax._
 
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
@@ -44,7 +45,7 @@ object FeatureExtractor {
 
     StacItem(
       s"${UUID.randomUUID}",
-      "0.9.0",
+      "1.0.0-rc.2",
       Nil,
       "Feature",
       feature.geom,
@@ -52,7 +53,10 @@ object FeatureExtractor {
       links = List(collectionLink, sourceItemLink),
       assets = Map.empty,
       collection = Some(inCollection.id),
-      properties = feature.data
+      properties = ItemProperties(
+        forItem.properties.datetime,
+        extensionFields = feature.data
+      )
     )
   }
 

--- a/application/src/main/scala/com/azavea/franklin/database/Filterables.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/Filterables.scala
@@ -18,11 +18,13 @@ trait FilterHelpers {
     def toFilterFragment: Option[Fragment] = {
       temporalExtent.value match {
         case Some(start) :: Some(end) :: _ =>
-          Some(fr"(datetime >= $start AND datetime <= $end)")
+          Some(
+            fr"(datetime >= $start AND datetime <= $end) OR (start_datetime >= $start AND end_datetime <= $end)"
+          )
         case Some(start) :: _ =>
-          Some(fr"datetime >= $start")
+          Some(fr"(datetime >= $start OR start_datetime >= $start)")
         case _ :: Some(end) :: _ =>
-          Some(fr"datetime <= $end")
+          Some(fr"(datetime <= $end OR end_datetime <= $end)")
         case _ => None
       }
     }

--- a/application/src/test/scala/com/azavea/franklin/api/services/CollectionItemsServiceSpec.scala
+++ b/application/src/test/scala/com/azavea/franklin/api/services/CollectionItemsServiceSpec.scala
@@ -170,10 +170,15 @@ class CollectionItemsServiceSpec
 
       val sourceAssetsWithoutNulls = update.assets.asJson
 
+      val updateProperties = update.properties
+
+      val updatedProperties = updated.properties
+
       (updated.stacExtensions should beTypedEqualTo(update.stacExtensions)) and
         (resultAssetsWithoutNulls should beTypedEqualTo(sourceAssetsWithoutNulls)) and
         (updated.geometry should beTypedEqualTo(update.geometry)) and
-        (updated.bbox should beTypedEqualTo(update.bbox))
+        (updated.bbox should beTypedEqualTo(update.bbox)) and
+        (updatedProperties should beTypedEqualTo(updateProperties))
   }
 
   def patchItemExpectation = prop { (stacCollection: StacCollection, stacItem: StacItem) =>

--- a/application/src/test/scala/com/azavea/franklin/api/services/FiltersFor.scala
+++ b/application/src/test/scala/com/azavea/franklin/api/services/FiltersFor.scala
@@ -1,8 +1,8 @@
 package com.azavea.franklin.api.services
 
-import cats.{Monoid, Semigroup}
 import cats.data.NonEmptyList
 import cats.syntax.all._
+import cats.{Monoid, Semigroup}
 import com.azavea.franklin.database.SearchFilters
 import com.azavea.stac4s.jvmTypes.TemporalExtent
 import com.azavea.stac4s.{ItemDatetime, StacCollection, StacItem, TwoDimBbox}

--- a/application/src/test/scala/com/azavea/franklin/api/services/FiltersFor.scala
+++ b/application/src/test/scala/com/azavea/franklin/api/services/FiltersFor.scala
@@ -64,7 +64,17 @@ object FiltersFor {
       case ItemDatetime.PointInTime(instant) =>
         TemporalExtent(instant.minusSeconds(60), Some(instant.plusSeconds(60)))
       case ItemDatetime.TimeRange(start, end) =>
-        TemporalExtent(start.minusSeconds(60), Some(end.plusSeconds(60)))
+        val milli = start.toEpochMilli % 3
+        if (milli == 0) {
+          // test start and end with full overlap
+          TemporalExtent(start.minusSeconds(60), Some(end.plusSeconds(60)))
+        } else if (milli == 1) {
+          // test start before the range start with open end
+          TemporalExtent(start.minusSeconds(60), None)
+        } else {
+          // test end after the range end with open start
+          TemporalExtent(None, end.plusSeconds(60))
+        }
     }
     SearchFilters(
       None,
@@ -133,8 +143,18 @@ object FiltersFor {
     val temporalExtent = item.properties.datetime match {
       case ItemDatetime.PointInTime(instant) =>
         TemporalExtent(instant.minusSeconds(60), Some(instant.minusSeconds(30)))
-      case ItemDatetime.TimeRange(start, _) =>
-        TemporalExtent(start.minusSeconds(60), Some(start.minusSeconds(30)))
+      case ItemDatetime.TimeRange(start, end) =>
+        val milli = start.toEpochMilli % 3
+        if (milli == 0) {
+          // test no intersection with range
+          TemporalExtent(start.minusSeconds(60), Some(start.minusSeconds(30)))
+        } else if (milli == 1) {
+          // test start after the range end with open end
+          TemporalExtent(end.plusSeconds(60), None)
+        } else {
+          // test end before the range start with open start
+          TemporalExtent(None, start.minusSeconds(60))
+        }
     }
     SearchFilters(
       None,

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -36,7 +36,7 @@ object Versions {
   val Slf4jVersion            = "1.7.30"
   val Specs2Version           = "4.11.0"
   val SpireVersion            = "0.13.0"
-  val Stac4SVersion           = "0.3.0"
+  val Stac4SVersion           = "0.4.0"
   val SttpClientVersion       = "2.2.9"
   val SttpShared              = "1.1.1"
   val SttpModelVersion        = "1.4.6"


### PR DESCRIPTION
## Overview

This PR makes a few changes now that `stac4s` models datetimes better:

- it updates the `datetime`, `start_datetime`, and `end_datetime` fields as appropriate on item insert, bulk insert, and update
- it updates the filter generators to test item search behavior
- it fixes a bug I didn't know about where search datetime filters were only checking the `datetime` column
- it significantly improves test coverage for search filter + item time interactions

### Checklist

- [x] New tests have been added or existing tests have been modified

### Notes

CI is gonna fail until the stac4s release that just happened is resolvable in Maven. Might be soon.

### Testing Instructions

- import a catalog on a fully up-to-date Franklin that's already been migrated
- do some time filtering
- everything should work as you expect
- everything else is exercised by tests

Closes #724 
