### PR TITLE
Fix PaginationToken Circe codecs

### DIFF
--- a/application/src/test/scala/com/azavea/franklin/api/TestClient.scala
+++ b/application/src/test/scala/com/azavea/franklin/api/TestClient.scala
@@ -80,4 +80,10 @@ class TestClient[F[_]: Sync](
       collection: StacCollection
   ): Resource[F, (StacCollection, StacItem)] =
     (getCollectionResource(collection), getItemResource(collection, item)).tupled
+
+  def getCollectionItemsResource(
+      items: List[StacItem],
+      collection: StacCollection
+  ): Resource[F, (StacCollection, List[StacItem])] =
+    (getCollectionResource(collection), items.traverse(getItemResource(collection, _))).tupled
 }

--- a/application/src/test/scala/com/azavea/franklin/api/services/FiltersFor.scala
+++ b/application/src/test/scala/com/azavea/franklin/api/services/FiltersFor.scala
@@ -189,4 +189,13 @@ object FiltersFor {
     // just to cooperate with timeFilterFor
     concatenated.get
   }
+
+  def inclusiveFilters(collection: StacCollection): SearchFilters = {
+    val filters: NonEmptyList[Option[SearchFilters]] =
+      NonEmptyList.of(collectionFilterFor(collection).some)
+    val concatenated = filters.combineAll
+    // guaranteed to succeed, since most of the filters are being converted into options
+    // just to cooperate with timeFilterFor
+    concatenated.get
+  }
 }

--- a/application/src/test/scala/com/azavea/franklin/api/services/SearchServiceSpec.scala
+++ b/application/src/test/scala/com/azavea/franklin/api/services/SearchServiceSpec.scala
@@ -6,10 +6,12 @@ import cats.syntax.all._
 import com.azavea.franklin.Generators
 import com.azavea.franklin.api.{TestClient, TestServices}
 import com.azavea.franklin.database.{SearchFilters, TestDatabaseSpec}
-import com.azavea.franklin.datamodel.StacSearchCollection
+import com.azavea.franklin.datamodel.{PaginationToken, StacSearchCollection}
 import com.azavea.stac4s.testing.JvmInstances._
 import com.azavea.stac4s.testing._
-import com.azavea.stac4s.{StacCollection, StacItem}
+import com.azavea.stac4s.{StacCollection, StacItem, StacLinkType}
+import eu.timepit.refined.types.numeric.NonNegInt
+import io.circe.syntax._
 import org.http4s.circe.CirceEntityDecoder._
 import org.http4s.circe.CirceEntityEncoder._
 import org.http4s.{Method, Request, Uri}
@@ -24,14 +26,15 @@ class SearchServiceSpec
   This specification verifies that the Search Service sensibly finds and excludes items
 
   The search service should:
-    - search with POST search filters               $postSearchFiltersExpectation
-    - search with GET search filters                $getSearchFiltersExpectation
-    - find an item with filters designed to find it $findItemWhenExpected
-    - not find items when excluded by time          $dontFindTimeFilters
-    - not find items when excluded by bbox          $dontFindBboxFilters
-    - not find items when excluded by intersection  $dontFindGeomFilters
-    - not find items when excluded by collection    $dontFindCollectionFilters
-    - not find items when excluded by item          $dontFindItemFilters
+    - search with POST search filters                       $postSearchFiltersExpectation
+    - search with GET search filters                        $getSearchFiltersExpectation
+    - find an item with filters designed to find it         $findItemWhenExpected
+    - find two items with filters designed to find it       $find2ItemsWhenExpected
+    - not find items when excluded by time                  $dontFindTimeFilters
+    - not find items when excluded by bbox                  $dontFindBboxFilters
+    - not find items when excluded by intersection          $dontFindGeomFilters
+    - not find items when excluded by collection            $dontFindCollectionFilters
+    - not find items when excluded by item                  $dontFindItemFilters
 """
   val testServices = new TestServices[IO](transactor)
 
@@ -115,6 +118,51 @@ class SearchServiceSpec
 
     val result = requestIO.unsafeRunSync.get
     result.features.head.id should beEqualTo(stacItem.id)
+  }
+
+  def find2ItemsWhenExpected = prop {
+    (stacItem1: StacItem, stacItem2: StacItem, stacCollection: StacCollection) =>
+      val resourceIO = testClient map {
+        _.getCollectionItemsResource(stacItem1 :: stacItem2 :: Nil, stacCollection)
+      }
+      val requestIO = resourceIO flatMap { resource =>
+        def getSearchCollection(searchFilters: SearchFilters): IO[Option[StacSearchCollection]] = {
+          val request =
+            Request[IO](method = Method.POST, uri = Uri.unsafeFromString(s"/search"))
+              .withEntity(searchFilters.asJson)
+          (for {
+            resp    <- testServices.searchService.routes.run(request)
+            decoded <- OptionT.liftF { resp.as[StacSearchCollection] }
+          } yield decoded).value
+        }
+
+        resource.use {
+          case (collection, _) =>
+            val inclusiveParams =
+              FiltersFor.inclusiveFilters(collection).copy(limit = NonNegInt.unsafeFrom(1).some)
+            val result1 = getSearchCollection(inclusiveParams)
+
+            val result2 = result1
+              .flatMap {
+                _.traverse { r =>
+                  /** This line intentionally decodes next token [[String]] into [[PaginationToken]] */
+                  val next = r.links.collectFirst {
+                    case l if l.rel == StacLinkType.Next =>
+                      l.href.split("next=").last.asJson.as[PaginationToken].toOption
+                  }.flatten
+                  getSearchCollection(inclusiveParams.copy(next = next))
+                }
+              }
+              .map(_.flatten)
+
+            (result1, result2).tupled
+        }
+      }
+
+      val (Some(result1), Some(result2)) = requestIO.unsafeRunSync()
+
+      result1.features.head.id should beEqualTo(stacItem1.id)
+      result2.features.head.id should beEqualTo(stacItem2.id)
   }
 
   def dontFindTimeFilters =

--- a/application/src/test/scala/com/azavea/franklin/api/services/SearchServiceSpec.scala
+++ b/application/src/test/scala/com/azavea/franklin/api/services/SearchServiceSpec.scala
@@ -139,12 +139,12 @@ class SearchServiceSpec
         resource.use {
           case (collection, _) =>
             val inclusiveParams =
-              FiltersFor.inclusiveFilters(collection).copy(limit = NonNegInt.unsafeFrom(1).some)
+              FiltersFor.inclusiveFilters(collection).copy(limit = NonNegInt.from(1).toOption)
             val result1 = getSearchCollection(inclusiveParams)
 
             val result2 = result1
               .flatMap {
-                _.traverse { r =>
+                _.flatTraverse { r =>
                   /** This line intentionally decodes next token [[String]] into [[PaginationToken]] */
                   val next = r.links.collectFirst {
                     case l if l.rel == StacLinkType.Next =>
@@ -153,7 +153,6 @@ class SearchServiceSpec
                   getSearchCollection(inclusiveParams.copy(next = next))
                 }
               }
-              .map(_.flatten)
 
             (result1, result2).tupled
         }


### PR DESCRIPTION
## Overview

This PR fixes PaginationToken circe codecs. Without it post requests with the passed `next` token doesn't work. I discovered this issue in terms of https://github.com/azavea/stac4s/pull/327

### Checklist

- [x] New tests have been added or existing tests have been modified

