### PR TITLE
Update stac compatibility to 1.0.0

### DIFF
--- a/application/src/main/scala/com/azavea/franklin/api/endpoints/CollectionEndpoints.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/endpoints/CollectionEndpoints.scala
@@ -1,6 +1,7 @@
 package com.azavea.franklin.api.endpoints
 
 import cats.effect.Concurrent
+import com.azavea.franklin.api.schemas._
 import com.azavea.franklin.error.NotFound
 import com.azavea.stac4s.StacCollection
 import io.circe._

--- a/application/src/main/scala/com/azavea/franklin/api/endpoints/SearchEndpoints.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/endpoints/SearchEndpoints.scala
@@ -4,8 +4,7 @@ import cats.effect.Concurrent
 import com.azavea.franklin.api.schemas._
 import com.azavea.franklin.database._
 import com.azavea.franklin.datamodel.PaginationToken
-import com.azavea.stac4s.Bbox
-import com.azavea.stac4s.jvmTypes.TemporalExtent
+import com.azavea.stac4s.{Bbox, TemporalExtent}
 import eu.timepit.refined.types.numeric.NonNegInt
 import io.circe._
 import sttp.capabilities.fs2.Fs2Streams

--- a/application/src/main/scala/com/azavea/franklin/api/schemas/package.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/schemas/package.scala
@@ -2,23 +2,26 @@ package com.azavea.franklin.api
 
 import cats.data.NonEmptyList
 import cats.syntax.either._
+import cats.syntax.invariant._
 import cats.syntax.traverse._
 import com.azavea.franklin.database.{temporalExtentFromString, temporalExtentToString}
 import com.azavea.franklin.datamodel.PaginationToken
 import com.azavea.franklin.error.InvalidPatch
 import com.azavea.stac4s._
-import com.azavea.stac4s.jvmTypes.TemporalExtent
 import eu.timepit.refined.types.string.NonEmptyString
 import geotrellis.vector.Geometry
 import io.circe.syntax._
 import io.circe.{Encoder, Json}
 import sttp.tapir.Codec.PlainCodec
+import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
 import sttp.tapir.{Codec, DecodeResult, Schema}
 
 import scala.util.Try
 
 package object schemas {
+
+  implicit val schemaStacCollection: Schema[StacCollection] = Schema(schemaForCirceJson.schemaType)
 
   implicit val schemaForTemporalExtent: Schema[TemporalExtent] = Schema(
     schemaForCirceJson.schemaType

--- a/application/src/main/scala/com/azavea/franklin/crawler/CatalogStacImport.scala
+++ b/application/src/main/scala/com/azavea/franklin/crawler/CatalogStacImport.scala
@@ -9,7 +9,6 @@ import com.azavea.franklin.database.{StacCollectionDao, StacItemDao}
 import com.azavea.stac4s.StacLinkType._
 import com.azavea.stac4s._
 import com.azavea.stac4s.extensions.label.LabelItemExtension
-import com.azavea.stac4s.jvmTypes.TemporalExtent
 import com.azavea.stac4s.syntax._
 import doobie.ConnectionIO
 import doobie.implicits._
@@ -152,7 +151,7 @@ class CatalogStacImport(val catalogRoot: String) {
                         )
                       )
                     ),
-                    ().asJsonObject,
+                    Map.empty,
                     forItem.properties.asJson.asObject.getOrElse(JsonObject.empty),
                     List(parentCollectionLink, derivedFromItemLink),
                     Some(Map.empty)

--- a/application/src/main/scala/com/azavea/franklin/database/Filterables.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/Filterables.scala
@@ -2,7 +2,7 @@ package com.azavea.franklin.database
 
 import cats.syntax.all._
 import com.azavea.franklin.datamodel._
-import com.azavea.stac4s.jvmTypes.TemporalExtent
+import com.azavea.stac4s.TemporalExtent
 import doobie.implicits._
 import doobie.postgres.circe.jsonb.implicits._
 import doobie.refined.implicits._
@@ -16,14 +16,14 @@ trait FilterHelpers {
   implicit class TemporalExtentWithFilter(temporalExtent: TemporalExtent) {
 
     def toFilterFragment: Option[Fragment] = {
-      temporalExtent.value match {
-        case Some(start) :: Some(end) :: _ =>
+      temporalExtent match {
+        case TemporalExtent(Some(start), Some(end)) =>
           Some(
             fr"(datetime >= $start AND datetime <= $end) OR (start_datetime >= $start AND end_datetime <= $end)"
           )
-        case Some(start) :: _ =>
+        case TemporalExtent(Some(start), _) =>
           Some(fr"(datetime >= $start OR start_datetime >= $start)")
-        case _ :: Some(end) :: _ =>
+        case TemporalExtent(_, Some(end)) =>
           Some(fr"(datetime <= $end OR end_datetime <= $end)")
         case _ => None
       }

--- a/application/src/main/scala/com/azavea/franklin/database/SearchFilters.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/SearchFilters.scala
@@ -3,8 +3,7 @@ package com.azavea.franklin.database
 import cats.syntax.all._
 import com.azavea.franklin.api.schemas.bboxToString
 import com.azavea.franklin.datamodel.{PaginationToken, Query}
-import com.azavea.stac4s.Bbox
-import com.azavea.stac4s.jvmTypes.TemporalExtent
+import com.azavea.stac4s.{Bbox, TemporalExtent}
 import eu.timepit.refined.types.numeric.NonNegInt
 import geotrellis.vector.Geometry
 import geotrellis.vector.{io => _, _}

--- a/application/src/main/scala/com/azavea/franklin/database/StacItemDao.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/StacItemDao.scala
@@ -9,7 +9,6 @@ import com.azavea.franklin.datamodel.SearchMethod
 import com.azavea.franklin.extensions.paging.PagingLinkExtension
 import com.azavea.stac4s._
 import com.azavea.stac4s.extensions.periodic.PeriodicExtent
-import com.azavea.stac4s.jvmTypes.TemporalExtent
 import com.azavea.stac4s.syntax._
 import doobie.Fragment
 import doobie.free.connection.ConnectionIO
@@ -120,7 +119,7 @@ object StacItemDao extends Dao[StacItem] {
               val anchorInstant =
                 (collection.extent.temporal.interval.headOption flatMap {
                   (interval: TemporalExtent) =>
-                    interval.value.find(_.isDefined)
+                    List(interval.start, interval.end).find(_.isDefined)
                 }).flatten
               anchorInstant.fold(
                 Either.left[InvalidTimeForPeriod.type, StacItem](InvalidTimeForPeriod)

--- a/application/src/main/scala/com/azavea/franklin/database/database.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/database.scala
@@ -36,6 +36,7 @@ package object database extends CirceJsonbMeta with GeotrellisWktMeta with Filte
 
   def temporalExtentFromString(str: String): Either[String, TemporalExtent] = {
     str.split("/").toList match {
+      case ".." :: ".." :: _ => Right(TemporalExtent(None, None))
       case ".." :: endString :: _ =>
         val parsedEnd: Either[Throwable, Instant] = stringToInstant(endString)
         parsedEnd match {

--- a/application/src/main/scala/com/azavea/franklin/database/database.scala
+++ b/application/src/main/scala/com/azavea/franklin/database/database.scala
@@ -3,8 +3,7 @@ package com.azavea.franklin
 import cats.data.NonEmptyList
 import cats.syntax.all._
 import com.azavea.franklin.datamodel.BulkExtent
-import com.azavea.stac4s.jvmTypes.TemporalExtent
-import com.azavea.stac4s.{Bbox, StacItem, ThreeDimBbox, TwoDimBbox}
+import com.azavea.stac4s.{Bbox, StacItem, TemporalExtent, ThreeDimBbox, TwoDimBbox}
 import doobie.implicits.javasql._
 import doobie.util.meta.Meta
 import doobie.util.{Read, Write}
@@ -25,11 +24,13 @@ package object database extends CirceJsonbMeta with GeotrellisWktMeta with Filte
     (s: String) => Either.catchNonFatal(Instant.parse(s))
 
   def temporalExtentToString(te: TemporalExtent): String = {
-    te.value match {
-      case Some(start) :: Some(end) :: _ if start != end => s"${start.toString}/${end.toString}"
-      case Some(start) :: Some(end) :: _ if start == end => s"${start.toString}"
-      case Some(start) :: None :: _                      => s"${start.toString}/.."
-      case None :: Some(end) :: _                        => s"../${end.toString}"
+    te match {
+      case TemporalExtent(Some(start), Some(end)) if start != end =>
+        s"${start.toString}/${end.toString}"
+      case TemporalExtent(Some(start), Some(end)) if start == end => s"${start.toString}"
+      case TemporalExtent(Some(start), None)                      => s"${start.toString}/.."
+      case TemporalExtent(None, Some(end))                        => s"../${end.toString}"
+      case _                                                      => "../.."
     }
   }
 

--- a/application/src/main/scala/com/azavea/franklin/datamodel/package.scala
+++ b/application/src/main/scala/com/azavea/franklin/datamodel/package.scala
@@ -55,14 +55,14 @@ package object datamodel {
   implicit class CollectionStacExtent(stacExtent: StacExtent) {
 
     def startTime = {
-      stacExtent.temporal.interval.flatMap(_.value.headOption).flatten match {
+      stacExtent.temporal.interval.flatMap(_.start) match {
         case l if l.isEmpty => None
         case l              => Some(l.min)
       }
     }
 
     def endTime = {
-      stacExtent.temporal.interval.flatMap(_.value.lift(1)).flatten match {
+      stacExtent.temporal.interval.flatMap(_.end) match {
         case l if l.isEmpty => None
         case l              => Some(l.max)
       }

--- a/application/src/test/scala/com/azavea/franklin/api/services/FiltersFor.scala
+++ b/application/src/test/scala/com/azavea/franklin/api/services/FiltersFor.scala
@@ -4,8 +4,7 @@ import cats.data.NonEmptyList
 import cats.syntax.all._
 import cats.{Monoid, Semigroup}
 import com.azavea.franklin.database.SearchFilters
-import com.azavea.stac4s.jvmTypes.TemporalExtent
-import com.azavea.stac4s.{ItemDatetime, StacCollection, StacItem, TwoDimBbox}
+import com.azavea.stac4s.{ItemDatetime, StacCollection, StacItem, TemporalExtent, TwoDimBbox}
 import geotrellis.vector.Extent
 import io.circe.syntax._
 

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -36,7 +36,7 @@ object Versions {
   val Slf4jVersion            = "1.7.30"
   val Specs2Version           = "4.12.0"
   val SpireVersion            = "0.13.0"
-  val Stac4SVersion           = "0.4.0"
+  val Stac4SVersion           = "0.5.0"
   val SttpClientVersion       = "2.2.9"
   val SttpShared              = "1.1.1"
   val SttpModelVersion        = "1.4.7"


### PR DESCRIPTION
## Overview

This PR updates stac4s to v0.5.0, which updates STAC compatibility to 1.0.0.

### Checklist

- ~New tests have been added or existing tests have been modified~

### Notes

The changes mainly have to do with TemporalExtents -- instead of a refined type, they're now a normal case class. API tests still pass, so I'm not too worried about the changes.

### Testing Instructions

- Just tests

Closes azavea/raster-foundry-platform#1259
