### PR TITLE
Quick milestone fixes

### DIFF
--- a/application/src/main/resources/migrations/V16__add_cascade_for_item_histograms.sql
+++ b/application/src/main/resources/migrations/V16__add_cascade_for_item_histograms.sql
@@ -1,0 +1,7 @@
+ALTER TABLE
+    item_asset_histograms DROP CONSTRAINT item_asset_histograms_item_id_fkey;
+
+ALTER TABLE
+    item_asset_histograms
+ADD
+    CONSTRAINT item_asset_histograms_item_id_fkey FOREIGN KEY (item_id) REFERENCES collection_items (id) ON DELETE CASCADE;

--- a/application/src/main/scala/com/azavea/franklin/api/Server.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/Server.scala
@@ -10,6 +10,7 @@ import com.azavea.franklin.api.endpoints.{
   SearchEndpoints,
   TileEndpoints
 }
+import com.azavea.franklin.api.middleware.AccessLoggingMiddleware
 import com.azavea.franklin.api.services._
 import com.azavea.franklin.extensions.validation.{collectionExtensionsRef, itemExtensionsRef}
 import com.azavea.stac4s.{`application/json`, StacLink, StacLinkType}
@@ -35,7 +36,6 @@ import scala.concurrent.ExecutionContext
 
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import com.azavea.franklin.api.middleware.AccessLoggingMiddleware
 
 object Server extends IOApp.WithContext {
 

--- a/application/src/main/scala/com/azavea/franklin/api/Server.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/Server.scala
@@ -35,6 +35,7 @@ import scala.concurrent.ExecutionContext
 
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import com.azavea.franklin.api.middleware.AccessLoggingMiddleware
 
 object Server extends IOApp.WithContext {
 
@@ -141,9 +142,10 @@ $$$$
         ).routes
         landingPageRoutes = new LandingPageService[IO](apiConfig).routes
         router = CORS(
-          ResponseLogger.httpRoutes(false, false)(
-            collectionRoutes <+> searchRoutes <+> tileRoutes <+> landingPageRoutes <+> docRoutes
-          )
+          new AccessLoggingMiddleware(
+            collectionRoutes <+> searchRoutes <+> tileRoutes <+> landingPageRoutes <+> docRoutes,
+            logger
+          ).withLogging(true)
         ).orNotFound
         serverBuilderBlocker <- Blocker[IO]
         server <- {

--- a/application/src/main/scala/com/azavea/franklin/api/endpoints/TileEndpoints.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/endpoints/TileEndpoints.scala
@@ -91,11 +91,12 @@ class TileEndpoints[F[_]: Concurrent](enableTiles: Boolean, pathPrefix: Option[S
       .name("collectionFootprintTileJSON")
 
   val collectionMosaicEndpoint
-      : Endpoint[CollectionMosaicRequest, Unit, Array[Byte], Fs2Streams[F]] =
+      : Endpoint[CollectionMosaicRequest, NotFound, Array[Byte], Fs2Streams[F]] =
     endpoint.get
       .in(collectionRasterTileParameters)
       .out(rawBinaryBody[Array[Byte]])
       .out(header("content-type", "image/png"))
+      .errorOut(oneOf(statusMapping(NF, jsonBody[NotFound].description("not found"))))
       .description(
         "Raster tile endpoint for collection mosaic"
       )

--- a/application/src/main/scala/com/azavea/franklin/api/middleware/AccessLoggingMiddleware.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/middleware/AccessLoggingMiddleware.scala
@@ -1,0 +1,60 @@
+package com.azavea.franklin.api.middleware
+
+import cats.data.Kleisli
+import cats.effect.Sync
+import cats.syntax.functor._
+import io.circe.syntax._
+import org.http4s.util.CaseInsensitiveString
+import org.http4s.{HttpRoutes, Request}
+
+import java.time.Instant
+import io.chrisdavenport.log4cats.Logger
+import cats.data.OptionT
+
+class AccessLoggingMiddleware[F[_]: Sync](
+    service: HttpRoutes[F],
+    logger: Logger[F]
+) {
+
+  def withLogging(enabled: Boolean) = {
+    if (!enabled) service
+    else {
+      Kleisli { (request: Request[F]) =>
+        val requestStart = Instant.now
+        val headerWhitelist: Set[CaseInsensitiveString] =
+          Set(
+            CaseInsensitiveString("user-agent"),
+            CaseInsensitiveString("accept-encoding"),
+            CaseInsensitiveString("referer"),
+            CaseInsensitiveString("origin"),
+            CaseInsensitiveString("X-Amzn-Trace-Id")
+          )
+        val headers =
+          Map(
+            request.headers.toList.filter(header => headerWhitelist.contains(header.name)) map {
+              header => header.name.toString.toLowerCase -> header.value.asJson
+            }: _*
+          )
+        val requestData =
+          Map(
+            "method"       -> request.method.toString.asJson,
+            "uri"          -> s"${request.uri}".asJson,
+            "httpVersion"  -> s"${request.httpVersion}".asJson,
+            "requesterIp"  -> (request.remote map { _.toString }).asJson,
+            "forwardedFor" -> (request.from map { _.toString }).asJson
+          ) ++ headers
+        service.run(request) flatMap { resp =>
+          val requestEnd = Instant.now
+          val duration   = (requestEnd.toEpochMilli - requestStart.toEpochMilli)
+          val responseData = Map(
+            "durationInMillis" -> duration.asJson,
+            "statusCode"       -> resp.status.code.asJson
+          )
+          OptionT.liftF {
+            logger.info((requestData ++ responseData).asJson.noSpaces) map { _ => resp }
+          }
+        }
+      }
+    }
+  }
+}

--- a/application/src/main/scala/com/azavea/franklin/api/middleware/AccessLoggingMiddleware.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/middleware/AccessLoggingMiddleware.scala
@@ -1,15 +1,15 @@
 package com.azavea.franklin.api.middleware
 
 import cats.data.Kleisli
+import cats.data.OptionT
 import cats.effect.Sync
 import cats.syntax.functor._
+import io.chrisdavenport.log4cats.Logger
 import io.circe.syntax._
 import org.http4s.util.CaseInsensitiveString
 import org.http4s.{HttpRoutes, Request}
 
 import java.time.Instant
-import io.chrisdavenport.log4cats.Logger
-import cats.data.OptionT
 
 class AccessLoggingMiddleware[F[_]: Sync](
     service: HttpRoutes[F],

--- a/application/src/main/scala/com/azavea/franklin/api/services/SearchService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/SearchService.scala
@@ -50,8 +50,9 @@ class SearchService[F[_]: Concurrent](
       }
       ((items, links), count) <- (itemsFib, countFib).tupled.join
     } yield {
-      val withApiHost  = items map { _.updateLinksWithHost(apiConfig) }
-      val searchResult = StacSearchCollection(Context(items.length, count), withApiHost, links)
+      val withApiHost = items map { _.updateLinksWithHost(apiConfig) }
+      val searchResult =
+        StacSearchCollection(Context(limit, items.length, count), withApiHost, links)
       val updatedFeatures = searchResult.features
         .map { item =>
           ((item.collection, enableTiles) match {

--- a/application/src/main/scala/com/azavea/franklin/datamodel/Context.scala
+++ b/application/src/main/scala/com/azavea/franklin/datamodel/Context.scala
@@ -8,6 +8,7 @@ object Context {
 }
 
 case class Context(
+    limit: Int,
     returned: Int,
     matched: Int
 )

--- a/build.sbt
+++ b/build.sbt
@@ -42,10 +42,6 @@ lazy val commonSettings = Seq(
     "org.slf4j",
     "slf4j-simple"
   ),
-  unusedCompileDependenciesFilter -= moduleFilter(
-    "ch.qos.logback",
-    "logback-classic"
-  ),
   excludeDependencies ++= Seq(
     "log4j"     % "log4j",
     "org.slf4j" % "slf4j-log4j12",
@@ -83,7 +79,6 @@ lazy val applicationSettings = commonSettings ++ Seq(
 )
 
 lazy val applicationDependencies = Seq(
-  "ch.qos.logback"               % "logback-classic"                 % Versions.LogbackVersion,
   "software.amazon.awssdk"       % "sdk-core"                        % Versions.AWSSdk2Version,
   "com.amazonaws"                % "aws-java-sdk-core"               % Versions.AWSVersion,
   "com.amazonaws"                % "aws-java-sdk-s3"                 % Versions.AWSVersion,


### PR DESCRIPTION
## Overview

This PR adds a few quick fixes to support the first tagged release. It:

- Adds request logging in a nice json format that plays nicely with cloud service logs parsers
- Adds a cascade to the item reference on histograms so items that you put in a histogram can ever be deleted
- Returns a 404 instead of an empty tile with a 200 when you make a request for a mosaic that's not in a collection
- Includes the `limit` value in the search context property

### Checklist

- ~New tests have been added or existing tests have been modified~ These things aren't really testable aside from "didn't break the server", which is exercised in existing tests, mostly, except for mosaics, which have their own "figure out how to test this better" issue (#829)

### Testing Instructions

- just CI

Closes #255 

Closes #884 

Closes #859 

Closes #793
