### PR TITLE
Fix and test temporal extent parsing

### DIFF
--- a/application/src/test/scala/com/azavea/franklin/database/TemporalExtentFromStringSpec.scala
+++ b/application/src/test/scala/com/azavea/franklin/database/TemporalExtentFromStringSpec.scala
@@ -3,9 +3,9 @@ package com.azavea.franklin.database
 import com.azavea.stac4s.TemporalExtent
 import org.specs2.Specification
 
+import java.sql.Timestamp
 import java.time.Instant
 import java.time.Period
-import java.sql.Timestamp
 
 class TemporalExtentFromStringSpec extends Specification {
   def is = s2"""

--- a/application/src/test/scala/com/azavea/franklin/database/TemporalExtentFromStringSpec.scala
+++ b/application/src/test/scala/com/azavea/franklin/database/TemporalExtentFromStringSpec.scala
@@ -1,0 +1,117 @@
+package com.azavea.franklin.database
+
+import com.azavea.stac4s.TemporalExtent
+import org.specs2.Specification
+
+import java.time.Instant
+import java.time.Period
+import java.sql.Timestamp
+
+class TemporalExtentFromStringSpec extends Specification {
+  def is = s2"""
+    This specification verifies that temporal extents can be parsed using a number of
+    widely used string formats.
+
+    Example cases:
+      - datetime=1996-12-19T16:39:57-00:00                                   $testSingleTimeMinus0
+      - datetime=1996-12-19T16:39:57+00:00                                   $testSingelTimePlus0
+      - datetime=1996-12-19T16:39:57-08:00                                   $testSingleTimeMinus8
+      - datetime=1996-12-19T16:39:57+08:00                                   $testSingleTimePlus8
+      - datetime=/1985-04-12T23:20:50.52Z                                    $testEmptyStringPreSlash
+      - datetime=1985-04-12T23:20:50.52Z/                                    $testEmptyStringPostSlash
+      - datetime=1985-04-12T23:20:50.52+01:00/1986-04-12T23:20:50.52Z+01:00  $testTwoTimesBothPluses
+      - datetime=1985-04-12T23:20:50.52-01:00/1986-04-12T23:20:50.52Z-01:00  $testTwoTimesBothMinuses
+      - datetime=1937-01-01T12:00:27.87+01:00                                $testTimeWithSecondsFraction
+      - datetime=1937-01-01T12:00:27.8710+01:00                              $testTimeWithFourDecimalSeconds
+      - datetime=1937-01-01T12:00:27.8+01:00                                 $testTimeWithSingleDecimalSeconds
+      - datetime=2020-07-23T00:00:00.000+03:00                               $testTimeWithThreeDecimalSeconds
+      - datetime=1985-04-12T23:20:50.Z                                       $testTrailingDecimal
+    """
+
+  private def testExtentString(s: String, expectedExtent: TemporalExtent) =
+    temporalExtentFromString(s) must_== Right(expectedExtent)
+
+  def testSingleTimeMinus0 = {
+    val instant = Instant.parse("1996-12-19T16:39:57Z")
+    testExtentString(
+      "1996-12-19T16:39:57-00:00",
+      TemporalExtent(
+        Some(instant),
+        Some(instant)
+      )
+    )
+  }
+
+  def testSingelTimePlus0 = {
+    val instant = Instant.parse("1996-12-19T16:39:57Z")
+    testExtentString("1996-12-19T16:39:57+00:00", TemporalExtent(Some(instant), Some(instant)))
+  }
+
+  def testSingleTimeMinus8 = {
+    val instant = Instant.parse("1996-12-20T00:39:57Z")
+    testExtentString(
+      "1996-12-19T16:39:57-08:00",
+      TemporalExtent(Some(instant), Some(instant))
+    )
+  }
+
+  def testSingleTimePlus8 = {
+    val instant = Instant.parse("1996-12-19T08:39:57Z")
+    testExtentString("1996-12-19T16:39:57+08:00", TemporalExtent(Some(instant), Some(instant)))
+  }
+
+  def testEmptyStringPreSlash = {
+    val instant = Instant.parse("1985-04-12T23:20:50.52Z")
+    testExtentString("/1985-04-12T23:20:50.52Z", TemporalExtent(None, Some(instant)))
+  }
+
+  def testEmptyStringPostSlash = {
+    val instant = Instant.parse("1985-04-12T23:20:50.52Z")
+    testExtentString("1985-04-12T23:20:50.52Z/", TemporalExtent(Some(instant), None))
+  }
+
+  def testTwoTimesBothPluses = {
+    val start = Instant.parse("1985-04-12T22:20:50.52Z")
+    val end   = Instant.parse("1986-04-12T22:20:50.52Z")
+    testExtentString(
+      "1985-04-12T23:20:50.52+01:00/1986-04-12T23:20:50.52+01:00",
+      TemporalExtent(Some(start), Some(end))
+    )
+  }
+
+  def testTwoTimesBothMinuses = {
+    val start = Instant.parse("1985-04-13T00:20:50.52Z")
+    val end   = Instant.parse("1986-04-13T00:20:50.52Z")
+    testExtentString(
+      "1985-04-12T23:20:50.52-01:00/1986-04-12T23:20:50.52-01:00",
+      TemporalExtent(Some(start), Some(end))
+    )
+  }
+
+  def testTimeWithSecondsFraction = {
+    val instant = Instant.parse("1937-01-01T11:00:27.87Z")
+    testExtentString("1937-01-01T12:00:27.87+01:00", TemporalExtent(Some(instant), Some(instant)))
+  }
+
+  def testTimeWithFourDecimalSeconds = {
+    val instant = Instant.parse("1937-01-01T11:00:27.8710Z")
+    testExtentString("1937-01-01T12:00:27.8710+01:00", TemporalExtent(Some(instant), Some(instant)))
+  }
+
+  def testTimeWithSingleDecimalSeconds = {
+    val instant = Instant.parse("1937-01-01T11:00:27.8Z")
+    testExtentString("1937-01-01T12:00:27.8+01:00", TemporalExtent(Some(instant), Some(instant)))
+  }
+
+  def testTimeWithThreeDecimalSeconds = {
+    val instant = Instant.parse("2020-07-22T21:00:00.000Z")
+    testExtentString("2020-07-23T00:00:00.000+03:00", TemporalExtent(Some(instant), Some(instant)))
+
+  }
+
+  def testTrailingDecimal = {
+    val instant = Instant.parse("1985-04-12T23:20:50.Z")
+    testExtentString("1985-04-12T23:20:50.Z", TemporalExtent(Some(instant), Some(instant)))
+  }
+
+}


### PR DESCRIPTION
## Overview

This PR re-uses the RFC3339 formatter from stac4s for string parsing instead of ad hoc throwing `Instant.parse` at the sides of temporal extents and hoping for the best.

### Checklist

- [x] New tests have been added or existing tests have been modified

### Notes

In three cases I deviated from the test cases in the linked issue:

- two examples had difficult to interpret times -- they included both a `Z` for no offset and an offset string. I removed the `Z` and just went with the offset string in the example
- another example was a duplicate

### Testing Instructions

- just tests

Closes #788 (if applicable)
