### PR TITLE
Use conf urls instead of req

### DIFF
--- a/application/src/main/scala/com/azavea/franklin/api/services/LandingPageService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/LandingPageService.scala
@@ -61,9 +61,9 @@ class LandingPageService[F[_]: Concurrent](apiConfig: ApiConfig)(
   )
 
   private val conformances: List[NonEmptyString] = List[NonEmptyString](
-    "http://www.opengis.net/spec/ogcapi-features-1/1.0/req/core",
-    "http://www.opengis.net/spec/ogcapi-features-1/1.0/req/oas30",
-    "http://www.opengis.net/spec/ogcapi-features-1/1.0/req/geojson",
+    "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
+    "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30",
+    "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson",
     "https://api.stacspec.org/v1.0.0-beta.1/core",
     "https://api.stacspec.org/v1.0.0-beta.1/item-search",
     "https://api.stacspec.org/v1.0.0-beta.1/item-search#context",


### PR DESCRIPTION
## Overview

This PR switches the URLs for the OGC conformance URLs.

### Checklist

- ~New tests have been added or existing tests have been modified~

Closes #799 (if applicable)
