### PR TITLE
Improve etag support

### DIFF
--- a/application/src/main/scala/com/azavea/franklin/api/endpoints/CollectionItemEndpoints.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/endpoints/CollectionItemEndpoints.scala
@@ -63,12 +63,11 @@ class CollectionItemEndpoints[F[_]: Concurrent](
       .description("A single feature")
       .name("collectionItemUnique")
 
-  val collectionItemTiles: Endpoint[(String, String), NotFound, (Json, String), Fs2Streams[F]] =
+  val collectionItemTiles: Endpoint[(String, String), NotFound, Json, Fs2Streams[F]] =
     base.get
       .in(path[String] / "items" / path[String] / "tiles")
       .out(jsonBody[Json])
       .errorOut(oneOf(statusMapping(NF, jsonBody[NotFound].description("not found"))))
-      .out(header[String]("ETag"))
       .description("An item's tile endpoints")
       .name("collectionItemTiles")
 

--- a/application/src/main/scala/com/azavea/franklin/api/endpoints/CollectionItemEndpoints.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/endpoints/CollectionItemEndpoints.scala
@@ -2,6 +2,7 @@ package com.azavea.franklin.api.endpoints
 
 import cats.effect.Concurrent
 import com.azavea.franklin.api.schemas._
+import com.azavea.franklin.datamodel.IfMatchMode
 import com.azavea.franklin.datamodel.PaginationToken
 import com.azavea.franklin.error.{
   CrudError,
@@ -90,11 +91,13 @@ class CollectionItemEndpoints[F[_]: Concurrent](
       .name("postItem")
 
   val putItem
-      : Endpoint[(String, String, StacItem, String), CrudError, (Json, String), Fs2Streams[F]] =
+      : Endpoint[(String, String, StacItem, IfMatchMode), CrudError, (Json, String), Fs2Streams[
+        F
+      ]] =
     base.put
       .in(path[String] / "items" / path[String])
       .in(accumulatingJsonBody[StacItem])
-      .in(header[String]("If-Match"))
+      .in(header[IfMatchMode]("If-Match"))
       .out(jsonBody[Json])
       .out(header[String]("ETag"))
       .errorOut(
@@ -123,11 +126,11 @@ class CollectionItemEndpoints[F[_]: Concurrent](
       .out(statusCode(StatusCode.NoContent))
 
   val patchItem
-      : Endpoint[(String, String, Json, String), CrudError, (Json, String), Fs2Streams[F]] =
+      : Endpoint[(String, String, Json, IfMatchMode), CrudError, (Json, String), Fs2Streams[F]] =
     base.patch
       .in(path[String] / "items" / path[String])
       .in(accumulatingJsonBody[Json])
-      .in(header[String]("If-Match"))
+      .in(header[IfMatchMode]("If-Match"))
       .out(jsonBody[Json])
       .out(header[String]("ETag"))
       .errorOut(

--- a/application/src/main/scala/com/azavea/franklin/api/schemas/package.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/schemas/package.scala
@@ -5,6 +5,7 @@ import cats.syntax.either._
 import cats.syntax.invariant._
 import cats.syntax.traverse._
 import com.azavea.franklin.database.{temporalExtentFromString, temporalExtentToString}
+import com.azavea.franklin.datamodel.IfMatchMode
 import com.azavea.franklin.datamodel.PaginationToken
 import com.azavea.franklin.error.InvalidPatch
 import com.azavea.stac4s._
@@ -91,4 +92,6 @@ package object schemas {
   implicit val schemaForStacLink: Schema[StacLinkType] =
     Schema.schemaForString.map(s => s.asJson.as[StacLinkType].toOption)(_.repr)
 
+  implicit val codecIfMatchMode: Codec.PlainCodec[IfMatchMode] =
+    Codec.string.mapDecode(s => DecodeResult.Value(IfMatchMode.fromString(s)))(_.toString)
 }

--- a/application/src/main/scala/com/azavea/franklin/api/services/CollectionItemsService.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/services/CollectionItemsService.scala
@@ -222,7 +222,7 @@ class CollectionItemsService[F[_]: Concurrent](
       rawCollectionId: String,
       rawItemId: String,
       itemUpdate: StacItem,
-      etag: String
+      etag: IfMatchMode
   ): F[Either[CrudError, (Json, String)]] = {
     val itemId       = URLDecoder.decode(rawItemId, StandardCharsets.UTF_8.toString)
     val collectionId = URLDecoder.decode(rawCollectionId, StandardCharsets.UTF_8.toString)
@@ -261,7 +261,7 @@ class CollectionItemsService[F[_]: Concurrent](
       rawCollectionId: String,
       rawItemId: String,
       jsonPatch: Json,
-      etag: String
+      etag: IfMatchMode
   ): F[Either[CrudError, (Json, String)]] = {
     val itemId       = URLDecoder.decode(rawItemId, StandardCharsets.UTF_8.toString)
     val collectionId = URLDecoder.decode(rawCollectionId, StandardCharsets.UTF_8.toString)

--- a/application/src/main/scala/com/azavea/franklin/datamodel/IfMatchMode.scala
+++ b/application/src/main/scala/com/azavea/franklin/datamodel/IfMatchMode.scala
@@ -1,0 +1,26 @@
+package com.azavea.franklin.datamodel
+
+import cats.kernel.Eq
+
+sealed abstract class IfMatchMode(repr: String) {
+  override def toString = repr
+  def matches(s: String): Boolean
+}
+
+object IfMatchMode {
+
+  case object YOLO extends IfMatchMode("*") {
+    def matches(tag: String) = true
+  }
+
+  case class Safe(s: String) extends IfMatchMode(s) {
+    def matches(tag: String) = s == tag
+  }
+
+  implicit val eqIfMatchMode: Eq[IfMatchMode] = Eq.fromUniversalEquals
+
+  def fromString: String => IfMatchMode = {
+    case "*" => YOLO
+    case s   => Safe(s)
+  }
+}

--- a/application/src/main/scala/com/azavea/franklin/error/CrudError.scala
+++ b/application/src/main/scala/com/azavea/franklin/error/CrudError.scala
@@ -1,5 +1,6 @@
 package com.azavea.franklin.error
 
+import com.azavea.stac4s.StacItem
 import io.circe.generic.semiauto._
 import io.circe.{Codec => _, _}
 
@@ -19,7 +20,8 @@ object ValidationError {
   implicit val decValidationError: Decoder[ValidationError] = deriveDecoder
 }
 
-case class MidAirCollision(msg: String) extends CrudError
+case class MidAirCollision(msg: String, currentEtag: String, currentItem: StacItem)
+    extends CrudError
 
 object MidAirCollision {
   implicit val encMidAirCollision: Encoder[MidAirCollision] = deriveEncoder

--- a/application/src/test/scala/com/azavea/franklin/Generators.scala
+++ b/application/src/test/scala/com/azavea/franklin/Generators.scala
@@ -112,4 +112,11 @@ trait Generators extends NumericInstances {
   implicit val arbSearchFilters   = Arbitrary { searchFiltersGen }
   implicit val arbPaginationToken = Arbitrary { paginationTokenGen }
   implicit val arbMapCenter       = Arbitrary { mapCenterGen }
+
+  private def ifMatchGen: Gen[IfMatchMode] = Gen.oneOf(
+    Gen.const(IfMatchMode.YOLO),
+    nonEmptyAlphaStringGen map { IfMatchMode.Safe(_) }
+  )
+
+  implicit val arbIfMatchMode = Arbitrary { ifMatchGen }
 }

--- a/application/src/test/scala/com/azavea/franklin/api/services/CollectionItemsServiceSpec.scala
+++ b/application/src/test/scala/com/azavea/franklin/api/services/CollectionItemsServiceSpec.scala
@@ -7,6 +7,7 @@ import com.azavea.franklin.Generators
 import com.azavea.franklin.api.{TestClient, TestServices}
 import com.azavea.franklin.database.TestDatabaseSpec
 import com.azavea.franklin.datamodel.CollectionItemsResponse
+import com.azavea.franklin.datamodel.IfMatchMode
 import com.azavea.stac4s.testing.JvmInstances._
 import com.azavea.stac4s.testing._
 import com.azavea.stac4s.{StacCollection, StacItem}
@@ -138,7 +139,7 @@ class CollectionItemsServiceSpec
   }
 
   def updateItemExpectation = prop {
-    (stacCollection: StacCollection, stacItem: StacItem, update: StacItem) =>
+    (stacCollection: StacCollection, stacItem: StacItem, update: StacItem, mode: IfMatchMode) =>
       val updateIO = (testClient, testServices.collectionItemsService).tupled flatMap {
         case (client, collectionItemsService) =>
           client.getCollectionItemResource(stacItem, stacCollection) use {
@@ -154,7 +155,8 @@ class CollectionItemsServiceSpec
               val request = Request[IO](
                 method = Method.PUT,
                 Uri.unsafeFromString(s"/collections/$encodedCollectionId/items/$encodedItemId"),
-                headers = Headers.of(Header("If-Match", s"$etag"))
+                headers = Headers.of(Header("If-Match", (if (mode == IfMatchMode.YOLO) { "*" }
+                                                         else { s"$etag" })))
               ).withEntity(toUpdate)
               (for {
                 response <- collectionItemsService.routes.run(request)
@@ -181,38 +183,40 @@ class CollectionItemsServiceSpec
         (updatedProperties should beTypedEqualTo(updateProperties))
   }
 
-  def patchItemExpectation = prop { (stacCollection: StacCollection, stacItem: StacItem) =>
-    val updateIO = (testClient, testServices.collectionItemsService).tupled flatMap {
-      case (client, collectionItemsService) =>
-        client.getCollectionItemResource(stacItem, stacCollection) use {
-          case (collection, item) =>
-            val encodedCollectionId =
-              URLEncoder.encode(collection.id, StandardCharsets.UTF_8.toString)
-            val encodedItemId = URLEncoder.encode(item.id, StandardCharsets.UTF_8.toString)
-            val etag          = item.##
-            val patch         = Map("properties" -> Map("veryUnlikelyProperty" -> true).asJson)
+  def patchItemExpectation = prop {
+    (stacCollection: StacCollection, stacItem: StacItem, mode: IfMatchMode) =>
+      val updateIO = (testClient, testServices.collectionItemsService).tupled flatMap {
+        case (client, collectionItemsService) =>
+          client.getCollectionItemResource(stacItem, stacCollection) use {
+            case (collection, item) =>
+              val encodedCollectionId =
+                URLEncoder.encode(collection.id, StandardCharsets.UTF_8.toString)
+              val encodedItemId = URLEncoder.encode(item.id, StandardCharsets.UTF_8.toString)
+              val etag          = item.##
+              val patch         = Map("properties" -> Map("veryUnlikelyProperty" -> true).asJson)
 
-            val request = Request[IO](
-              method = Method.PATCH,
-              Uri.unsafeFromString(s"/collections/$encodedCollectionId/items/$encodedItemId"),
-              headers = Headers.of(Header("If-Match", s"$etag"))
-            ).withEntity(patch)
+              val request = Request[IO](
+                method = Method.PATCH,
+                Uri.unsafeFromString(s"/collections/$encodedCollectionId/items/$encodedItemId"),
+                headers = Headers.of(Header("If-Match", (if (mode == IfMatchMode.YOLO) { "*" }
+                                                         else { s"$etag" })))
+              ).withEntity(patch)
 
-            (for {
-              response <- collectionItemsService.routes.run(request)
-              decoded  <- OptionT.liftF { response.as[StacItem] }
-            } yield decoded).value
-        }
-    }
+              (for {
+                response <- collectionItemsService.routes.run(request)
+                decoded  <- OptionT.liftF { response.as[StacItem] }
+              } yield decoded).value
+          }
+      }
 
-    val result = updateIO.unsafeRunSync
-    result flatMap { res =>
-      res.properties.asJson.as[Map[String, Json]].toOption
-    } flatMap {
-      _.get("veryUnlikelyProperty")
-    } flatMap {
-      _.as[Boolean].toOption
-    } must beSome(true)
+      val result = updateIO.unsafeRunSync
+      result flatMap { res =>
+        res.properties.asJson.as[Map[String, Json]].toOption
+      } flatMap {
+        _.get("veryUnlikelyProperty")
+      } flatMap {
+        _.as[Boolean].toOption
+      } must beSome(true)
   }
 
 }

--- a/application/src/test/scala/com/azavea/franklin/api/services/CollectionItemsServiceSpec.scala
+++ b/application/src/test/scala/com/azavea/franklin/api/services/CollectionItemsServiceSpec.scala
@@ -80,7 +80,7 @@ class CollectionItemsServiceSpec
     val testIO: IO[Result] = (testClient, testServices.collectionsService).tupled flatMap {
       case (client, collectionsService) =>
         client.getCollectionItemResource(stacItem, stacCollection) use {
-          case (collection, item) =>
+          case (collection, (item, _)) =>
             val encodedCollectionId =
               URLEncoder.encode(collection.id, StandardCharsets.UTF_8.toString)
             val request = Request[IO](
@@ -107,7 +107,7 @@ class CollectionItemsServiceSpec
     val fetchIO = (testClient, testServices.collectionItemsService).tupled flatMap {
       case (client, collectionItemsService) =>
         client.getCollectionItemResource(stacItem, stacCollection) use {
-          case (collection, item) =>
+          case (collection, (item, _)) =>
             val encodedCollectionId =
               URLEncoder.encode(collection.id, StandardCharsets.UTF_8.toString)
             val encodedItemId = URLEncoder.encode(item.id, StandardCharsets.UTF_8.toString)
@@ -143,11 +143,10 @@ class CollectionItemsServiceSpec
       val updateIO = (testClient, testServices.collectionItemsService).tupled flatMap {
         case (client, collectionItemsService) =>
           client.getCollectionItemResource(stacItem, stacCollection) use {
-            case (collection, item) =>
+            case (collection, (item, etag)) =>
               val encodedCollectionId =
                 URLEncoder.encode(collection.id, StandardCharsets.UTF_8.toString)
               val encodedItemId = URLEncoder.encode(item.id, StandardCharsets.UTF_8.toString)
-              val etag          = item.##
               val toUpdate = update.copy(
                 links = item.links,
                 id = item.id
@@ -188,11 +187,10 @@ class CollectionItemsServiceSpec
       val updateIO = (testClient, testServices.collectionItemsService).tupled flatMap {
         case (client, collectionItemsService) =>
           client.getCollectionItemResource(stacItem, stacCollection) use {
-            case (collection, item) =>
+            case (collection, (item, etag)) =>
               val encodedCollectionId =
                 URLEncoder.encode(collection.id, StandardCharsets.UTF_8.toString)
               val encodedItemId = URLEncoder.encode(item.id, StandardCharsets.UTF_8.toString)
-              val etag          = item.##
               val patch         = Map("properties" -> Map("veryUnlikelyProperty" -> true).asJson)
 
               val request = Request[IO](

--- a/application/src/test/scala/com/azavea/franklin/api/services/CollectionsServiceSpec.scala
+++ b/application/src/test/scala/com/azavea/franklin/api/services/CollectionsServiceSpec.scala
@@ -118,7 +118,7 @@ class CollectionsServiceSpec
             case (collection, items) =>
               val encodedCollectionId =
                 URLEncoder.encode(collection.id, StandardCharsets.UTF_8.toString)
-              val item = items.head
+              val (item, _) = items.head
               val mosaicDefinition = if (item.assets.isEmpty) {
                 val name = "bogus asset name"
                 MosaicDefinition(
@@ -181,8 +181,8 @@ class CollectionsServiceSpec
               case (collection, items) =>
                 val encodedCollectionId =
                   URLEncoder.encode(collection.id, StandardCharsets.UTF_8.toString)
-                val item = items.head
-                val name = item.assets.keys.head
+                val (item, _) = items.head
+                val name      = item.assets.keys.head
                 val mosaicDefinition =
                   MosaicDefinition(
                     UUID.randomUUID,

--- a/application/src/test/scala/com/azavea/franklin/api/services/SearchServiceSpec.scala
+++ b/application/src/test/scala/com/azavea/franklin/api/services/SearchServiceSpec.scala
@@ -100,7 +100,7 @@ class SearchServiceSpec
     val resourceIO = testClient map { _.getCollectionItemResource(stacItem, stacCollection) }
     val requestIO = resourceIO flatMap { resource =>
       resource.use {
-        case (collection, item) =>
+        case (collection, (item, _)) =>
           val inclusiveParams =
             FiltersFor.inclusiveFilters(collection, item)
           val request =


### PR DESCRIPTION
## Overview

This PR makes several improvements to optimistic locking:

- it ensures consistency by using the headers instead of Scala's hash calculations in tests (
- it adds `*` support so that if you know you really don't care about the etag you can just skip it
- it returns the current item and current etag from the database in cases where you do care but happen to have a stale etag

### Checklist

- [x] New tests have been added or existing tests have been modified

### Testing Instructions

- Mostly exercised by tests, but if you fancy it, you can send a `PATCH` to an item with a random `If-Match` header and see the result in the 412 response

Closes #663 

Closes #774

Closes #781 
