### PR TITLE
Flip order for env vs flag for server attributes 

### DIFF
--- a/application/src/main/scala/com/azavea/franklin/commands/ApiOptions.scala
+++ b/application/src/main/scala/com/azavea/franklin/commands/ApiOptions.scala
@@ -68,34 +68,34 @@ trait ApiOptions {
     "Whether to respond to transaction requests, like adding or updating items. Default: 'false'."
 
   private val enableTransactions = Opts
-    .flag(
-      "with-transactions",
-      help = enableTransactionsHelp
-    )
-    .orFalse orElse Opts
     .env[String]("API_WITH_TRANSACTIONS", help = enableTransactionsHelp, metavar = "true||false")
     .mapValidated { s =>
       Validated
         .fromTry(Try(s.toBoolean))
         .leftMap(_ => s"Expected to find a value that can convert to a Boolean, but got $s")
         .toValidatedNel
-    } withDefault (false)
+    } orElse Opts
+    .flag(
+      "with-transactions",
+      help = enableTransactionsHelp
+    )
+    .orFalse
 
   private val enableTilesHelp = "Whether to include tile endpoints. Default: 'false'."
 
   private val enableTiles = Opts
-    .flag(
-      "with-tiles",
-      help = enableTilesHelp
-    )
-    .orFalse orElse Opts
     .env[String]("API_WITH_TILES", help = enableTilesHelp, metavar = "true||false")
     .mapValidated { s =>
       Validated
         .fromTry(Try(s.toBoolean))
         .leftMap(_ => s"Expected to find a value that can convert to a Boolean, but got $s")
         .toValidatedNel
-    } withDefault (false)
+    } orElse Opts
+    .flag(
+      "with-tiles",
+      help = enableTilesHelp
+    )
+    .orFalse
 
   private val runMigrations =
     Opts.flag("run-migrations", "Run migrations before the API server starts").orFalse
@@ -110,5 +110,5 @@ trait ApiOptions {
     enableTransactions,
     enableTiles,
     runMigrations
-  ) mapN ApiConfig
+  ) mapN ApiConfig.apply
 }


### PR DESCRIPTION
## Overview

This PR resolves configuration from env variables first for server with transactions and with tiles. The `orFalse` on the flag was necessary to turn it into an `Opt[Bool]`, but it was also making it so that the CLI 

### Checklist

- ~New tests have been added or existing tests have been modified~ not super straightforward to test configuration options 😢 maybe [continuous configuration testing](https://2021.splashcon.org/home/conflang-2021#program) will help with some ideas

### Testing Instructions

- fire up sbt with the env var config: `API_WITH_TRANSACTIONS=true ./sbt`
- start the server: `application/run serve --db-host=localhost`
- check the api spec -- `http :9090/open-api/spec.yaml | grep delete` -- you should get a hit
- stop the server
- start again with the tile flag -- `application/run serve --db-host=localhost --with-tiles`
- check the api spec -- `http :9090/open-api/spec.yaml | grep tiles` -- you should get a hit
- make sure transactions are still there as well -- `http :9090/open-api/spec.yaml | grep delete` -- you should get a hit
- stop sbt
- start it again, this time with the tiles env var: `API_WITH_TILES=true ./sbt`
- check for tiles in the spec, then add `--with-transactions` and check for both -- you should expect hits

Closes #969 