### PR TITLE
Support db configuration with full jdbc url

### DIFF
--- a/application/src/main/scala/com/azavea/franklin/api/Server.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/Server.scala
@@ -84,7 +84,7 @@ $$$$
   private def makeHttpRequest = AsyncHttpClientCatsBackend.resource[IO]() use { implicit backend =>
     basicRequest.get(uri"https://google.com").response(asString).send[IO] map {
       case resp if resp.code.code == 200 => println("Internet is accessible!")
-      case resp                          => print(resp.body)
+      case resp                          => println(s"Response body was: ${resp.body}")
     }
   }
 

--- a/application/src/main/scala/com/azavea/franklin/api/Server.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/Server.scala
@@ -82,6 +82,7 @@ $$$$
   }
 
   private def makeHttpRequest = AsyncHttpClientCatsBackend.resource[IO]() use { implicit backend =>
+    println("MAKING HTTP REQUEST")
     basicRequest.get(uri"https://google.com").response(asString).send[IO] map {
       case resp if resp.code.code == 200 => println("Internet is accessible!")
       case resp                          => println(s"Response body was: ${resp.body}")

--- a/application/src/main/scala/com/azavea/franklin/api/Server.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/Server.scala
@@ -87,11 +87,8 @@ $$$$
       for {
         connectionEc  <- ExecutionContexts.fixedThreadPool[IO](2)
         transactionEc <- ExecutionContexts.cachedThreadPool[IO]
-        xa <- HikariTransactor.newHikariTransactor[IO](
-          "org.postgresql.Driver",
-          dbConfig.jdbcUrl,
-          dbConfig.dbUser,
-          dbConfig.dbPass,
+        xa <- HikariTransactor.fromHikariConfig[IO](
+          dbConfig.toHikariConfig,
           connectionEc,
           Blocker.liftExecutionContext(transactionEc)
         )

--- a/application/src/main/scala/com/azavea/franklin/api/Server.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/Server.scala
@@ -72,6 +72,13 @@ $$$$
 
   implicit val serverOptions = ServerOptions.defaultServerOptions[IO]
 
+  // https://gist.github.com/dirkgr/20a00d30522c1381f0e2
+  private def classUrls(cl: ClassLoader): Array[java.net.URL] = cl match {
+    case null                       => Array()
+    case u: java.net.URLClassLoader => u.getURLs() ++ classUrls(cl.getParent)
+    case _                          => classUrls(cl.getParent)
+  }
+
   private def createServer(
       apiConfig: ApiConfig,
       dbConfig: DatabaseConfig
@@ -161,6 +168,10 @@ $$$$
 
   override def run(args: List[String]): IO[ExitCode] = {
     import Commands._
+
+    val urls = classUrls(this.getClass.getClassLoader)
+    println("Full classpath urls:")
+    println(urls.mkString("\n"))
 
     applicationCommand.parse(args, env = sys.env) map {
       case RunServer(apiConfig, dbConfig) if !apiConfig.runMigrations =>

--- a/application/src/main/scala/com/azavea/franklin/api/Server.scala
+++ b/application/src/main/scala/com/azavea/franklin/api/Server.scala
@@ -27,6 +27,7 @@ import org.http4s.implicits.{http4sLiteralsSyntax => _, _}
 import org.http4s.server.blaze._
 import org.http4s.server.middleware._
 import org.http4s.server.{Router, Server => HTTP4sServer}
+import sttp.client.SttpBackend
 import sttp.client._
 import sttp.client.asynchttpclient.cats.AsyncHttpClientCatsBackend
 import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
@@ -37,7 +38,6 @@ import scala.concurrent.ExecutionContext
 
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import sttp.client.SttpBackend
 
 object Server extends IOApp.WithContext {
 

--- a/application/src/main/scala/com/azavea/franklin/commands/Commands.scala
+++ b/application/src/main/scala/com/azavea/franklin/commands/Commands.scala
@@ -7,6 +7,7 @@ import cats.syntax.all._
 import com.azavea.franklin.crawler.CatalogStacImport
 import com.azavea.franklin.crawler.StacItemImporter
 import com.monovore.decline._
+import com.zaxxer.hikari.HikariDataSource
 import doobie.Transactor
 import doobie.free.connection.{rollback, setAutoCommit, unit}
 import doobie.util.transactor.Strategy
@@ -64,9 +65,7 @@ object Commands {
     Flyway
       .configure()
       .dataSource(
-        s"${dbConfig.jdbcUrl}",
-        dbConfig.dbUser,
-        dbConfig.dbPass
+        new HikariDataSource(dbConfig.toHikariConfig)
       )
       .locations("classpath:migrations/")
       .load()

--- a/application/src/main/scala/com/azavea/franklin/commands/DatabaseConfig.scala
+++ b/application/src/main/scala/com/azavea/franklin/commands/DatabaseConfig.scala
@@ -1,33 +1,101 @@
 package com.azavea.franklin.api.commands
 
+import cats.effect.Async
+import cats.effect.Blocker
 import cats.effect.ContextShift
 import cats.effect.IO
+import cats.effect.Resource
+import com.zaxxer.hikari.HikariConfig
 import doobie.free.connection.{rollback, setAutoCommit, unit}
 import doobie.util.transactor.Strategy
 import doobie.util.transactor.Transactor
 import eu.timepit.refined.types.numeric._
 
-final case class DatabaseConfig(
-    dbUser: String,
-    dbPass: String,
-    dbHost: String,
-    dbPort: PosInt,
-    dbName: String
-) {
-  val jdbcUrl = s"jdbc:postgresql://$dbHost:$dbPort/$dbName"
-  val driver  = "org.postgresql.Driver"
+import scala.concurrent.ExecutionContext
 
-  def getTransactor(dryRun: Boolean)(implicit cs: ContextShift[IO]) = {
-    Transactor.strategy.set(
-      Transactor.fromDriverManager[IO](
-        driver,
-        jdbcUrl,
-        dbUser,
-        dbPass
-      ),
-      if (dryRun) {
-        Strategy.default.copy(before = setAutoCommit(false), after = rollback, always = unit)
-      } else { Strategy.default }
-    )
+import java.util.concurrent.Executors
+import java.util.concurrent.ThreadFactory
+
+sealed abstract class DatabaseConfig {
+  val jdbcUrl: String
+  val driver: String = "org.postgresql.Driver"
+
+  def getTransactor(dryRun: Boolean)(implicit contextShift: ContextShift[IO]): Transactor[IO]
+
+  def toHikariConfig: HikariConfig
+}
+
+case object DatabaseConfig {
+
+  final case class FromComponents(
+      dbUser: String,
+      dbPass: String,
+      dbHost: String,
+      dbPort: PosInt,
+      dbName: String
+  ) extends DatabaseConfig {
+    val jdbcUrl = s"jdbc:postgresql://$dbHost:$dbPort/$dbName"
+
+    def getTransactor(dryRun: Boolean)(implicit contextShift: ContextShift[IO]) = {
+      Transactor.strategy.set(
+        Transactor.fromDriverManager[IO](
+          driver,
+          jdbcUrl,
+          dbUser,
+          dbPass
+        ),
+        if (dryRun) {
+          Strategy.default.copy(before = setAutoCommit(false), after = rollback, always = unit)
+        } else { Strategy.default }
+      )
+    }
+
+    def toHikariConfig: HikariConfig = {
+      val config = new HikariConfig()
+      config.setJdbcUrl(jdbcUrl)
+      config.setUsername(dbUser)
+      config.setPassword(dbPass)
+      config.setDriverClassName(driver)
+      config
+    }
   }
+
+  final case class FromConnectionString(
+      jdbcUrl: String
+  ) extends DatabaseConfig {
+
+    def getTransactor(dryRun: Boolean)(implicit contextShift: ContextShift[IO]): Transactor[IO] = {
+      val blockingEc = ExecutionContext.fromExecutor(
+        Executors.newCachedThreadPool(
+          new ThreadFactory {
+            def newThread(r: Runnable): Thread = {
+              val th = new Thread(r)
+              th.setName(s"doobie-blocking-ec-${th.getId}")
+              th.setDaemon(true)
+              th
+            }
+          }
+        )
+      )
+
+      Transactor.strategy.set(
+        Transactor.fromDriverManager[IO](
+          driver,
+          jdbcUrl,
+          Blocker.liftExecutionContext(blockingEc)
+        ),
+        if (dryRun) {
+          Strategy.default.copy(before = setAutoCommit(false), after = rollback, always = unit)
+        } else { Strategy.default }
+      )
+    }
+
+    def toHikariConfig: HikariConfig = {
+      val config = new HikariConfig()
+      config.setDriverClassName(driver)
+      config.setJdbcUrl(jdbcUrl)
+      config
+    }
+  }
+
 }

--- a/application/src/main/scala/com/azavea/franklin/commands/DatabaseOptions.scala
+++ b/application/src/main/scala/com/azavea/franklin/commands/DatabaseOptions.scala
@@ -71,7 +71,11 @@ trait DatabaseOptions {
         }
         select.toEither match {
           case Right(_) => true
-          case Left(_)  => false
+          case Left(e)  => 
+            println(s"Connection failure: ${e}")
+            println(s"Failure details:\n${e.getMessage}")
+            println(s"Stack trace:]n${e.getStackTrace}")
+            false
         }
       }
 }

--- a/application/src/main/scala/com/azavea/franklin/commands/DatabaseOptions.scala
+++ b/application/src/main/scala/com/azavea/franklin/commands/DatabaseOptions.scala
@@ -61,21 +61,21 @@ trait DatabaseOptions {
       databasePort,
       databaseName
     ).mapN { DatabaseConfig.FromComponents })
-      .validate(
-        e":boom: Unable to connect to database - please ensure database is configured and listening at entered port"
-      ) { config =>
-        val xa =
-          config.getTransactor(true)
-        val select = Try {
-          fr"SELECT 1".query[Int].unique.transact(xa).unsafeRunSync()
-        }
-        select.toEither match {
-          case Right(_) => true
-          case Left(e) =>
-            println(s"Connection failure: ${e}")
-            println(s"Failure details:\n${e.getMessage()}")
-            e.printStackTrace()
-            false
-        }
-      }
+  // .validate(
+  //   e":boom: Unable to connect to database - please ensure database is configured and listening at entered port"
+  // ) { config =>
+  //   val xa =
+  //     config.getTransactor(true)
+  //   val select = Try {
+  //     fr"SELECT 1".query[Int].unique.transact(xa).unsafeRunSync()
+  //   }
+  //   select.toEither match {
+  //     case Right(_) => true
+  //     case Left(e) =>
+  //       println(s"Connection failure: ${e}")
+  //       println(s"Failure details:\n${e.getMessage()}")
+  //       e.printStackTrace()
+  //       false
+  //   }
+  // }
 }

--- a/application/src/main/scala/com/azavea/franklin/commands/DatabaseOptions.scala
+++ b/application/src/main/scala/com/azavea/franklin/commands/DatabaseOptions.scala
@@ -45,25 +45,33 @@ trait DatabaseOptions {
   private val databaseUser = Opts.option[String]("db-user", help = databaseUserHelp) orElse Opts
     .env[String]("DB_USER", help = databaseUserHelp) withDefault (databaseOptionDefault)
 
+  private val databaseConnectionStringHelp =
+    "Complete JDBC connection string to use to connect to database"
+
+  private val connectionString = Opts.option[String](
+    "db-connection-string",
+    help = databaseConnectionStringHelp
+  ) orElse Opts.env[String]("DB_CONNECTION_STRING", help = databaseConnectionStringHelp)
+
   def databaseConfig(implicit contextShift: ContextShift[IO]): Opts[DatabaseConfig] =
-    ((
+    ((connectionString map { DatabaseConfig.FromConnectionString }) orElse (
       databaseUser,
       databasePassword,
       databaseHost,
       databasePort,
       databaseName
-    ) mapN DatabaseConfig).validate(
-      e":boom: Unable to connect to database - please ensure database is configured and listening at entered port"
-    ) { config =>
-      val xa =
-        Transactor
-          .fromDriverManager[IO](config.driver, config.jdbcUrl, config.dbUser, config.dbPass)
-      val select = Try {
-        fr"SELECT 1".query[Int].unique.transact(xa).unsafeRunSync()
+    ).mapN { DatabaseConfig.FromComponents })
+      .validate(
+        e":boom: Unable to connect to database - please ensure database is configured and listening at entered port"
+      ) { config =>
+        val xa =
+          config.getTransactor(true)
+        val select = Try {
+          fr"SELECT 1".query[Int].unique.transact(xa).unsafeRunSync()
+        }
+        select.toEither match {
+          case Right(_) => true
+          case Left(_)  => false
+        }
       }
-      select.toEither match {
-        case Right(_) => true
-        case Left(_)  => false
-      }
-    }
 }

--- a/application/src/main/scala/com/azavea/franklin/commands/DatabaseOptions.scala
+++ b/application/src/main/scala/com/azavea/franklin/commands/DatabaseOptions.scala
@@ -71,10 +71,10 @@ trait DatabaseOptions {
         }
         select.toEither match {
           case Right(_) => true
-          case Left(e)  => 
+          case Left(e) =>
             println(s"Connection failure: ${e}")
-            println(s"Failure details:\n${e.getMessage}")
-            println(s"Stack trace:]n${e.getStackTrace}")
+            println(s"Failure details:\n${e.getMessage()}")
+            e.printStackTrace()
             false
         }
       }

--- a/application/src/main/scala/com/azavea/franklin/commands/DatabaseOptions.scala
+++ b/application/src/main/scala/com/azavea/franklin/commands/DatabaseOptions.scala
@@ -61,21 +61,21 @@ trait DatabaseOptions {
       databasePort,
       databaseName
     ).mapN { DatabaseConfig.FromComponents })
-  // .validate(
-  //   e":boom: Unable to connect to database - please ensure database is configured and listening at entered port"
-  // ) { config =>
-  //   val xa =
-  //     config.getTransactor(true)
-  //   val select = Try {
-  //     fr"SELECT 1".query[Int].unique.transact(xa).unsafeRunSync()
-  //   }
-  //   select.toEither match {
-  //     case Right(_) => true
-  //     case Left(e) =>
-  //       println(s"Connection failure: ${e}")
-  //       println(s"Failure details:\n${e.getMessage()}")
-  //       e.printStackTrace()
-  //       false
-  //   }
-  // }
+      .validate(
+        e":boom: Unable to connect to database - please ensure database is configured and listening at entered port"
+      ) { config =>
+        val xa =
+          config.getTransactor(true)
+        val select = Try {
+          fr"SELECT 1".query[Int].unique.transact(xa).unsafeRunSync()
+        }
+        select.toEither match {
+          case Right(_) => true
+          case Left(e) =>
+            println(s"Connection failure: ${e}")
+            println(s"Failure details:\n${e.getMessage()}")
+            e.printStackTrace()
+            false
+        }
+      }
 }

--- a/application/src/main/scala/com/azavea/franklin/crawler/StacIO.scala
+++ b/application/src/main/scala/com/azavea/franklin/crawler/StacIO.scala
@@ -12,7 +12,6 @@ import io.circe.{CursorOp, Decoder, DecodingFailure, Error => CirceError, Parsin
 import sttp.client._
 import sttp.client.asynchttpclient.cats.AsyncHttpClientCatsBackend
 import sttp.client.circe._
-import sttp.model.{Uri => SttpUri}
 
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,37 @@ from the STAC API specification will be available. However, there are two additi
 enable for additional functionality. In both cases, the additional endpoints will be included in
 the server's OpenAPI specification at `<host>/open-api/spec.yaml`
 
+## Configuring your database connection
+
+You have two options for configuring the database. The first option is what's
+shown in the example  [startup command](./introduction#running-the-service). In
+that case, you specify a user, host, port, and password as separate arguments.
+
+Alternatively, you can specify a complete connection string. That connection
+string will look something like:
+
+```
+jdbc:postgresql://<host>/<database-name>?user=<user>&password=<password>
+```
+
+In general, it is safer to configure your database connection one component at a
+time. That allows you to ensure that each value is individually correct and
+leave assembling them into a strange looking string to Franklin. However,
+there's one circumstance in which you should use the JDBC URL option instead. If
+your cloud provider or internal IT systems have resulted in a database that
+requires an SSL connection, you should use the JDBC URL configuration. You can
+start the server in that case like:
+
+```
+application/run serve \
+  --db-connection-string \
+  jdbc:postgresql://localhost/franklin?user=franklin&password=franklin&ssl=true
+```
+
+This constraint was [originally
+discovered](https://github.com/azavea/franklin/issues/669) in a Google Cloud
+Platform environment but appears to be relevant in Azure settings as well.
+
 ## `--with-tiles`
 
 Enabling the `--with-tiles` flag will add a few different sorts of tile rendering.

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -17,6 +17,9 @@
       "0004-make-authentication-configurable-at-server-startup": {
         "title": "4 - Configurable Authentication at Server Startup"
       },
+      "0005-release-versioning": {
+        "title": "0005-release-versioning"
+      },
       "configuration": {
         "title": "Configuration"
       },


### PR DESCRIPTION
## Overview

This PR adds an alternative database connection configuration method using the full JDBC url.

### Checklist

- ~New tests have been added or existing tests have been modified~

### Testing Instructions

- Start up the local database: `docker-compose up -d database`
- Start the application with the env variable configuration: `DB_CONNECTION_STRING="jdbc:postgresql://localhost/franklin?user=franklin&password=franklin" sbt application/serve --run-migrations`
- Start the application with the CLI args configuration: `application/run serve --run-migrations --db-connection-string "jdbc:postgresql://localhost/franklin?user=franklin&password=franklin"`
- Confirm SSL is respected by setting `ssl=true` at the end of the connection string with one of those methods and noting that you can no longer connect to the db (because the local container doesn't have SSL configured)

Closes #669 
