### PR TITLE
Support using custom domain in deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,8 @@ npm-debug.log
 debug.log
 main.bundle.js.map
 data/*
+
+# copilot related artifacts
+deployment/copilot/api
+deployment/copilot/infra
+deployment/copilot/.workspace

--- a/deployment/cloudformation/README.md
+++ b/deployment/cloudformation/README.md
@@ -6,9 +6,20 @@ Deployment using [AWS CloudFormation CLI](https://docs.aws.amazon.com/cli/latest
 - [AWS Copilot CLI](https://aws.github.io/copilot-cli/docs/overview/)
 - [AWS CLI](https://aws.amazon.com/cli/)
 - A named profile configured (`aws configure --profile <your profile name>`) to specify which AWS account and region to deploy your service
+- A domain name registered with Amazon Route 53 in your account
 
 ## Instructions
-1. `copilot init`
+
+1. `copilot app init --domain <your registered DomainName here>`
+    
+    This command will ask you the application name. We will use `franklin` in this example. It is required that you have a registered domain name in Amazon Route53 before this step. After going through this tutorial, your load balanced franklin API service is going to be accessible publicly through `${ServiceName}.${EnvironmentName}.${ApplicationName}.${DomainName}`. Please refer to [here](https://aws.github.io/copilot-cli/docs/developing/domain/#how-do-i-configure-an-alias-for-my-service) if you want to configure an alias for your franklin api service. Under the hood, this step will configure the your AWS admininistration roles to enable use of AWS CloudFormation StackSets. For example, we will run `copilot app init --domain rasterfoundry.com` in this tutorial.
+
+    ```
+    Use existing application: No
+    Application name: franklin
+    ```
+
+2. `copilot init`
 
     This command will ask you questions about your preferences for the application. After answering, it will initialize the infra to manage the containerized services, set up an ECR repository for the image to be uploaded, and will create a `/copilot/franklin-api/manifest.yml` file that we will configure further. Use the following answers to get started. At the end, when it asks if to deploy to a test environment, answer `No`.
     
@@ -23,9 +34,9 @@ Deployment using [AWS CloudFormation CLI](https://docs.aws.amazon.com/cli/latest
     Port: 9090
     ```
 
-2. `copilot env init`
+3. `copilot env init`
 
-    This will create a new environment where the serivces will live. After answering the questions as below, it will link your named profile to the application to be deployed, create the common infrastructure that's shared between the services such as a VPC, an Application Load Balancer, and an ECS Cluster etc.
+    This will create a new environment where the serivces will live. After answering the questions as below, it will link your named profile to the application to be deployed, create the common infrastructure that's shared between the services such as a VPC, an Application Load Balancer, and an ECS Cluster etc. Under the hood, on CloudFormation, it wil create a stack for cross-regional resources to support the CodePipeline for this workspace, and a stack for the environment template for infrastructure shared among Copilot workloads.
 
     ```
     $ copilot env init
@@ -34,29 +45,31 @@ Deployment using [AWS CloudFormation CLI](https://docs.aws.amazon.com/cli/latest
     Default environment configuration? Yes, use default.
     ```
 
-3. Upload Aurora Serverless Config Template to S3
+4. Upload Aurora Serverless Config Template to S3
 
     ```
-    aws s3 cp ./franklin-api.addons.stack.yml s3://path/to/your/s3/franklin-api.addons.stack.yml
+    aws s3 cp ./api.addons.stack.yml s3://path/to/your/s3/franklin-api.addons.stack.yml
     ```
 
-4. Deploy the Franklin Production API Stack with CloudFormation
+5. Deploy the Franklin Production API Stack with CloudFormation
 
     Configure the parameters in `--parameter-overrides` as you like.
 
-    Note that the `S3 URL to the Aurora Serverless Template` in the following command should be the "Object URL", e.g.: `https://franklin-aurora-serverless-addson-stack.s3.amazonaws.com/franklin-api.addons.stack.yml`
+    Notes:
+    - the `<S3 URL to the Aurora Serverless Templat>` in the following command should be the "Object URL" from step 4, e.g.: `https://franklin-aurora-serverless-addson-stack.s3.amazonaws.com/franklin-api.addons.stack.yml`
+    - the `<Your custom DomainName>` in the following command should be the same as what you used in step one, which should be a registered Route53 domain name. For this example tutorial, we are using `rasterfoundry.com`
 
     ```
     $ aws cloudformation deploy \
-        --template-file ./franklin-api-production.stack.yml\
-        --stack-name franklin-production-franklin-api \
+        --template-file ./api-production.stack.yml\
+        --stack-name franklin-production-api \
         --capabilities CAPABILITY_IAM \
         --parameter-overrides \
             AppName=franklin \
             EnvName=production \
-            WorkloadName=franklin-api \
+            WorkloadName=api \
             ContainerImage=quay.io/azavea/franklin:latest \
-            AddonsTemplateURL="<>" \
+            AddonsTemplateURL="<S3 URL to the Aurora Serverless Template>" \
             TaskCPU=256 \
             TaskMemory=512 \
             TaskCount=1 \
@@ -64,9 +77,10 @@ Deployment using [AWS CloudFormation CLI](https://docs.aws.amazon.com/cli/latest
             ContainerPort=9090 \
             RulePath="/" \
             HTTPSEnabled=false \
-            TargetContainer=franklin-api \
+            TargetContainer=api \
             TargetPort=9090 \
             Stickiness=false \
+            DomainName=<Your custom DomainName>
         --tags \
             copilot-application=franklin \
             copilot-environment=production \

--- a/deployment/cloudformation/README.md
+++ b/deployment/cloudformation/README.md
@@ -25,10 +25,9 @@ Deployment using [AWS CloudFormation CLI](https://docs.aws.amazon.com/cli/latest
     
     ```
     $ copilot init
-    Use existing application: No
-    Application name: franklin
+    Use existing application: Yes // and choose franklin here
     Workload type: Load Balanced Web Service
-    Service name: franklin-api
+    Service name: api
     Dockerfile: Use an existing image instead
     Image: quay.io/azavea/franklin:latest
     Port: 9090

--- a/deployment/cloudformation/api-production.params.json
+++ b/deployment/cloudformation/api-production.params.json
@@ -2,7 +2,7 @@
   "Parameters" : { 
     "AppName": "franklin",
     "EnvName": "production",
-    "WorkloadName": "franklin-api",
+    "WorkloadName": "api",
     "ContainerImage": "quay.io/azavea/franklin:latest",
     "AddonsTemplateURL": "",
     "TaskCPU": "256",
@@ -11,14 +11,14 @@
     "LogRetention": "30",
     "ContainerPort": "9090",
     "RulePath": "/",
-    "HTTPSEnabled": "false",
-    "TargetContainer": "franklin-api",
+    "HTTPSEnabled": "true",
+    "TargetContainer": "api",
     "TargetPort": "9090",
     "Stickiness": "false"
   },
   "Tags": { 
     "copilot-application": "franklin",
     "copilot-environment": "production",
-    "copilot-service": "franklin-api"
+    "copilot-service": "api"
   }
 }

--- a/deployment/cloudformation/api-production.stack.yml
+++ b/deployment/cloudformation/api-production.stack.yml
@@ -37,6 +37,9 @@ Parameters:
   Stickiness:
     Type: String
     Default: false
+  DomainName:
+    Description: 'Registered custom domain name on Route53.'
+    Type: String
 Conditions:
   HTTPLoadBalancer: !Not
     - !Condition HTTPSLoadBalancer
@@ -69,9 +72,9 @@ Resources: # If a bucket URL is specified, that means the template exists.
         - Name: !Ref WorkloadName
           Image: !Ref ContainerImage
           Secrets:
-            - Name: FRANKLINAPICLUSTER_SECRET
+            - Name: APICLUSTER_SECRET
               ValueFrom:
-                Fn::GetAtt: [AddonsStack, Outputs.franklinapiclusterSecret]
+                Fn::GetAtt: [AddonsStack, Outputs.apiclusterSecret]
           # We pipe certain environment variables directly into the task definition.
           # This lets customers have access to, for example, their LB endpoint - which they'd
           # have no way of otherwise determining.
@@ -84,9 +87,9 @@ Resources: # If a bucket URL is specified, that means the template exists.
               Value: !Sub '${EnvName}'
             - Name: COPILOT_SERVICE_NAME
               Value: !Sub '${WorkloadName}'
-            - Name: FRANKLINAPICLUSTER_SECURITY_GROUP
+            - Name: APICLUSTER_SECURITY_GROUP
               Value:
-                Fn::GetAtt: [AddonsStack, Outputs.franklinapiclusterSecurityGroup]
+                Fn::GetAtt: [AddonsStack, Outputs.apiclusterSecurityGroup]
             - Name: DB_NAME
               Value:
                 Fn::GetAtt: [AddonsStack, Outputs.dbName]
@@ -112,6 +115,12 @@ Resources: # If a bucket URL is specified, that means the template exists.
             - --with-transactions
             - --with-tiles
             - --run-migrations
+            - --external-port
+            - 443
+            - --api-scheme
+            - https
+            - --api-host
+            - !Sub 'api.production.franklin.${DomainName}'
           PortMappings:
             - ContainerPort: !Ref ContainerPort
   ExecutionRole:
@@ -299,7 +308,7 @@ Resources: # If a bucket URL is specified, that means the template exists.
               - Fn::ImportValue: !Sub '${AppName}-${EnvName}-PublicSubnets'
           SecurityGroups:
             - Fn::ImportValue: !Sub '${AppName}-${EnvName}-EnvironmentSecurityGroup'
-            - Fn::GetAtt: [AddonsStack, Outputs.franklinapiclusterSecurityGroup]
+            - Fn::GetAtt: [AddonsStack, Outputs.apiclusterSecurityGroup]
       # This may need to be adjusted if the container takes a while to start up
       HealthCheckGracePeriodSeconds: 60
       LoadBalancers:

--- a/deployment/cloudformation/api.addons.stack.yml
+++ b/deployment/cloudformation/api.addons.stack.yml
@@ -9,41 +9,41 @@ Parameters:
         Type: String
         Description: The name of the service, job, or workflow being deployed.
     # Customize your Aurora Serverless cluster by setting the default value of the following parameters.
-    franklinapiclusterDBName:
+    apiclusterDBName:
         Type: String
         Description: The name of the initial database to be created in the DB cluster.
         Default: franklin
         # Cannot have special characters
         # Naming constraints: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html#RDS_Limits.Constraints
-    franklinapiclusterDBAutoPauseSeconds:
+    apiclusterDBAutoPauseSeconds:
         Type: Number
         Description: The duration in seconds before the cluster pauses.
         Default: 1000
 Mappings:
-    franklinapiclusterEnvScalingConfigurationMap:
+    apiclusterEnvScalingConfigurationMap:
         All:
             "DBMinCapacity": 2 # AllowedValues: [2, 4, 8, 16, 32, 64, 192, 384]
             "DBMaxCapacity": 8 # AllowedValues: [2, 4, 8, 16, 32, 64, 192, 384]
 Resources:
-    franklinapiclusterDBSubnetGroup:
+    apiclusterDBSubnetGroup:
         Type: 'AWS::RDS::DBSubnetGroup'
         Properties:
             DBSubnetGroupDescription: Group of Copilot private subnets for Aurora cluster.
             SubnetIds: !Split [',', {'Fn::ImportValue': !Sub '${App}-${Env}-PrivateSubnets'}]
-    franklinapiclusterSecurityGroup:
+    apiclusterSecurityGroup:
         Metadata:
-            'aws:copilot:description': 'A security group for your workload to access the DB cluster franklinapicluster'
+            'aws:copilot:description': 'A security group for your workload to access the DB cluster apicluster'
         Type: 'AWS::EC2::SecurityGroup'
         Properties:
-            GroupDescription: !Sub 'The Security Group for ${Name} to access DB cluster franklinapicluster.'
+            GroupDescription: !Sub 'The Security Group for ${Name} to access DB cluster apicluster.'
             VpcId:
                 Fn::ImportValue: !Sub '${App}-${Env}-VpcId'
             Tags:
                 - Key: Name
                   Value: !Sub 'copilot-${App}-${Env}-${Name}-Aurora'
-    franklinapiclusterDBClusterSecurityGroup:
+    apiclusterDBClusterSecurityGroup:
         Metadata:
-            'aws:copilot:description': 'A security group for your DB cluster franklinapicluster'
+            'aws:copilot:description': 'A security group for your DB cluster apicluster'
         Type: AWS::EC2::SecurityGroup
         Properties:
             GroupDescription: The Security Group for the database cluster.
@@ -52,10 +52,10 @@ Resources:
                   FromPort: 5432
                   IpProtocol: tcp
                   Description: !Sub 'From the Aurora Security Group of the workload ${Name}.'
-                  SourceSecurityGroupId: !Ref franklinapiclusterSecurityGroup
+                  SourceSecurityGroupId: !Ref apiclusterSecurityGroup
             VpcId:
                 Fn::ImportValue: !Sub '${App}-${Env}-VpcId'
-    franklinapiclusterAuroraSecret:
+    apiclusterAuroraSecret:
         Metadata:
             'aws:copilot:description': 'A Secrets Manager secret to store your DB credentials'
         Type: AWS::SecretsManager::Secret
@@ -67,7 +67,7 @@ Resources:
                 ExcludePunctuation: true
                 IncludeSpace: false
                 PasswordLength: 16
-    franklinapiclusterDBClusterParameterGroup:
+    apiclusterDBClusterParameterGroup:
         Metadata:
             'aws:copilot:description': 'A DB parameter group for engine configuration values'
         Type: 'AWS::RDS::DBClusterParameterGroup'
@@ -76,49 +76,49 @@ Resources:
             Family: 'aurora-postgresql10'
             Parameters:
                 client_encoding: 'UTF8'
-    franklinapiclusterDBCluster:
+    apiclusterDBCluster:
         Metadata:
-            'aws:copilot:description': 'The franklinapicluster Aurora Serverless database cluster'
+            'aws:copilot:description': 'The apicluster Aurora Serverless database cluster'
         Type: 'AWS::RDS::DBCluster'
         Properties:
-            MasterUsername: !Join ["", ['{{resolve:secretsmanager:', !Ref franklinapiclusterAuroraSecret, ":SecretString:username}}"]]
-            MasterUserPassword: !Join ["", ['{{resolve:secretsmanager:', !Ref franklinapiclusterAuroraSecret, ":SecretString:password}}"]]
-            DatabaseName: !Ref franklinapiclusterDBName
+            MasterUsername: !Join ["", ['{{resolve:secretsmanager:', !Ref apiclusterAuroraSecret, ":SecretString:username}}"]]
+            MasterUserPassword: !Join ["", ['{{resolve:secretsmanager:', !Ref apiclusterAuroraSecret, ":SecretString:password}}"]]
+            DatabaseName: !Ref apiclusterDBName
             Engine: 'aurora-postgresql'
             EngineVersion: '10.12'
             EngineMode: serverless
-            DBClusterParameterGroupName: !Ref franklinapiclusterDBClusterParameterGroup
-            DBSubnetGroupName: !Ref franklinapiclusterDBSubnetGroup
+            DBClusterParameterGroupName: !Ref apiclusterDBClusterParameterGroup
+            DBSubnetGroupName: !Ref apiclusterDBSubnetGroup
             VpcSecurityGroupIds:
-                - !Ref franklinapiclusterDBClusterSecurityGroup
+                - !Ref apiclusterDBClusterSecurityGroup
             ScalingConfiguration:
                 AutoPause: true
                 # Replace "All" below with "!Ref Env" to set different autoscaling limits per environment.
-                MinCapacity: !FindInMap [franklinapiclusterEnvScalingConfigurationMap, All, DBMinCapacity]
-                MaxCapacity: !FindInMap [franklinapiclusterEnvScalingConfigurationMap, All, DBMaxCapacity]
-                SecondsUntilAutoPause: !Ref franklinapiclusterDBAutoPauseSeconds
-    franklinapiclusterSecretAuroraClusterAttachment:
+                MinCapacity: !FindInMap [apiclusterEnvScalingConfigurationMap, All, DBMinCapacity]
+                MaxCapacity: !FindInMap [apiclusterEnvScalingConfigurationMap, All, DBMaxCapacity]
+                SecondsUntilAutoPause: !Ref apiclusterDBAutoPauseSeconds
+    apiclusterSecretAuroraClusterAttachment:
         Type: AWS::SecretsManager::SecretTargetAttachment
         Properties:
-            SecretId: !Ref franklinapiclusterAuroraSecret
-            TargetId: !Ref franklinapiclusterDBCluster
+            SecretId: !Ref apiclusterAuroraSecret
+            TargetId: !Ref apiclusterDBCluster
             TargetType: AWS::RDS::DBCluster
 Outputs:
-    franklinapiclusterSecret: # injected as FRANKLINAPICLUSTER_SECRET environment variable by Copilot.
+    apiclusterSecret: # injected as APICLUSTER_SECRET environment variable by Copilot.
         Description: "The JSON secret that holds the database username and password. Fields are 'host', 'port', 'dbname', 'username', 'password', 'dbClusterIdentifier' and 'engine'"
-        Value: !Ref franklinapiclusterAuroraSecret
-    franklinapiclusterSecurityGroup:
+        Value: !Ref apiclusterAuroraSecret
+    apiclusterSecurityGroup:
         Description: "The security group to attach to the workload."
-        Value: !Ref franklinapiclusterSecurityGroup
+        Value: !Ref apiclusterSecurityGroup
     dbName:
         Description: "The DB_NAME exported as env var for the API container"
-        Value: !Join ["", ['{{resolve:secretsmanager:', !Ref franklinapiclusterAuroraSecret, ":SecretString:dbname}}"]]
+        Value: !Join ["", ['{{resolve:secretsmanager:', !Ref apiclusterAuroraSecret, ":SecretString:dbname}}"]]
     dbHost:
         Description: "The DB_HOST exported as env var for the API container"
-        Value: !Join ["", ['{{resolve:secretsmanager:', !Ref franklinapiclusterAuroraSecret, ":SecretString:host}}"]]
+        Value: !Join ["", ['{{resolve:secretsmanager:', !Ref apiclusterAuroraSecret, ":SecretString:host}}"]]
     dbUser:
         Description: "The DB_USER exported as env var for the API container"
-        Value: !Join ["", ['{{resolve:secretsmanager:', !Ref franklinapiclusterAuroraSecret, ":SecretString:username}}"]]
+        Value: !Join ["", ['{{resolve:secretsmanager:', !Ref apiclusterAuroraSecret, ":SecretString:username}}"]]
     dbPassword:
         Description: "The DB_PASSWORD exported as env var for the API container"
-        Value: !Join ["", ['{{resolve:secretsmanager:', !Ref franklinapiclusterAuroraSecret, ":SecretString:password}}"]]
+        Value: !Join ["", ['{{resolve:secretsmanager:', !Ref apiclusterAuroraSecret, ":SecretString:password}}"]]

--- a/deployment/copilot/README.md
+++ b/deployment/copilot/README.md
@@ -46,9 +46,9 @@ Deployment using [AWS Copilot CLI](https://aws.github.io/copilot-cli/) is a quic
 
     ```
     $ copilot storage init
-    Only found one workload, defaulting to: franklin-api
+    Only found one workload, defaulting to: api
     Storage type: Aurora Serverless
-    Storage resource name: franklin-api-cluster
+    Storage resource name: api-cluster
     Database engine: PostgreSQL
     Initial database name: franklin
     ```


### PR DESCRIPTION
## Overview

This PR:
- updates the docs and template to support using custom domain for deployment
- updates arguments passed into the `serve` command upon container start up so that API responses `hrefs` are correct

### Checklist

- ~New tests have been added or existing tests have been modified~

### Testing Instructions

- Follow instructions in `./deployment/copilot/README.md` and make sure they work
- run `copilot app delete franklin` to remove all the related stacks
- Follow instructions in `./deployment/cloudformation/README.md` and make sure they work
- run `aws cloudformation delete-stack --stack-name franklin-production-api` to delete the `franklin-production-api` stack and its nested Aurora Serverless stack
- run `copilot app delete franklin` to delete the stacks related to the envs and configs

Closes https://github.com/azavea/raster-foundry-platform/issues/1373
