### PR TITLE
Add automated script for AWS Copilot deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,4 @@ main.bundle.js.map
 data/*
 
 # copilot related artifacts
-deployment/copilot/api
-deployment/copilot/infra
-deployment/copilot/.workspace
+copilot/

--- a/deployment/aws-copilot/README.md
+++ b/deployment/aws-copilot/README.md
@@ -6,6 +6,8 @@ Both options use this CLI to deploy your own Franklin APIs as a load-balanced we
 
 ## Prerequisites
 - [AWS Copilot CLI](https://aws.github.io/copilot-cli/docs/overview/)
+    - MacOS: `brew install aws/tap/copilot-cli`
+    - Linux (x86): `curl -Lo copilot https://github.com/aws/copilot-cli/releases/latest/download/copilot-linux && chmod +x copilot && sudo mv copilot /usr/local/bin/copilot && copilot --help`
 - [AWS CLI](https://aws.amazon.com/cli/)
 - [Docker](https://www.docker.com/products/docker-desktop)
 - A named profile configured (`aws configure --profile <your profile name>`) to specify which AWS account and region to deploy your service. For docs, see more [here](https://docs.aws.amazon.com/cli/latest/reference/configure/)
@@ -16,9 +18,10 @@ Both options use this CLI to deploy your own Franklin APIs as a load-balanced we
 ## Before you start
 
 At the root of this directory, if you want to take down the previously deployed Franklin API and DB to start a clean deploy:
-1. Run `copilot app delete franklin`.
-2. Answer `Y` if it asks you to confirm the deletion.
-3. After the command is finished, delete the `./copilot` directory.
+1. Ensure that `AWS_PROFILE` environment variable is set: i.e. `export AWS_PROFILE=franklin`
+2. Run `copilot app delete franklin`.
+3. Answer `Y` if it asks you to confirm the deletion.
+4. After the command is finished, delete the `./copilot` directory.
 
 ## If you make changes to configurations in the addons or the manifest after first deploy
 

--- a/deployment/aws-copilot/README.md
+++ b/deployment/aws-copilot/README.md
@@ -87,7 +87,7 @@ Deployment using [AWS Copilot CLI](https://aws.github.io/copilot-cli/) is a quic
     cp iam.yml ./copilot/api/addons/iam.yml
     ```
 
-5. `copilot env init -n production`
+5. `copilot env init -n production -a franklin`
 
     - This command will create a new environment `production` where the serivces will live.
     - After answering the questions as below, it will:
@@ -98,7 +98,7 @@ Deployment using [AWS Copilot CLI](https://aws.github.io/copilot-cli/) is a quic
       - etc
      - Under the hood, on CloudFormation, it wil create a stack for cross-regional resources to support the CodePipeline for this workspace, and a stack for the environment template for infrastructure shared among Copilot workloads for this application.
     ```
-    $ copilot env init -n production
+    $ copilot env init -n production -a franklin
     Credential source: [profile default]
     Default environment configuration? Yes, use default.
     ```
@@ -160,7 +160,7 @@ Deployment using [AWS Copilot CLI](https://aws.github.io/copilot-cli/) is a quic
         Default: <the S3 bucket URL for the CDN logs, e.g. rasterfoundry-production-logs-us-east-1.s3.amazonaws.com>
     ```
 
-7. `copilot deploy`
+7. `copilot deploy -a franklin -e production -n api`
 
     - This command will package the `manifest.yml` file and addons into `CloudFormation`, and create and/or update the ECS task definition and attached service.
     - Under the hood, this will create a stack that manages the franklin production API service, and the nested stack attached to the API service for DB and IAM role policy for the ECS task.
@@ -193,9 +193,9 @@ Deployment using [AWS Copilot CLI](https://aws.github.io/copilot-cli/) is a quic
     ```
 
 8.  Some commands to check the service
-    - `copilot svc show`: This command shows info about the deployed services, including the endpoints, capacity and related resources per environment.
-    - `copilot svc status`: This command shows the health statuses, e.g. service status, task status, and related CloudWatch alarms etc.
-    - `copilot svc logs`: This command shows the the logs of the deployed service.
+    - `copilot svc show -a franklin -n api`: This command shows info about the deployed services, including the endpoints, capacity and related resources per environment.
+    - `copilot svc status -a franklin -n api -e production`: This command shows the health statuses, e.g. service status, task status, and related CloudWatch alarms etc.
+    - `copilot svc logs -a franklin -n api -e production`: This command shows the the logs of the deployed service.
 
 ## How to take down the deployed Franklin API server?
 

--- a/deployment/aws-copilot/README.md
+++ b/deployment/aws-copilot/README.md
@@ -5,7 +5,7 @@ Deployment using [AWS Copilot CLI](https://aws.github.io/copilot-cli/) is a quic
 Both options use this CLI to deploy your own Franklin APIs as a load-balanced web service, with some suggested configurations added in addition to the default settings. In the end, it will provision an Application Load Balancer, security groups, an ECS service on Fargate to run `api` service, and attach a provisioned PostgreSQL RDS instance. It will add a CDN in front of the tile request endpoints as well.
 
 ## Prerequisites
-- [AWS Copilot CLI](https://aws.github.io/copilot-cli/docs/overview/)
+- [AWS Copilot CLI](https://aws.github.io/copilot-cli/docs/overview/): it is important to install from the official package
     - MacOS: `brew install aws/tap/copilot-cli`
     - Linux (x86): `curl -Lo copilot https://github.com/aws/copilot-cli/releases/latest/download/copilot-linux && chmod +x copilot && sudo mv copilot /usr/local/bin/copilot && copilot --help`
 - [AWS CLI](https://aws.amazon.com/cli/)
@@ -18,10 +18,10 @@ Both options use this CLI to deploy your own Franklin APIs as a load-balanced we
 ## Before you start
 
 At the root of this directory, if you want to take down the previously deployed Franklin API and DB to start a clean deploy:
-1. Ensure that `AWS_PROFILE` environment variable is set: i.e. `export AWS_PROFILE=franklin`
-2. Run `copilot app delete franklin`.
-3. Answer `Y` if it asks you to confirm the deletion.
-4. After the command is finished, delete the `./copilot` directory.
+1. Ensure that `AWS_PROFILE` environment variable is set: i.e. `export AWS_PROFILE=franklin`, note that `franklin` is my aws profile name, you should use your own created from the prerequisites section
+1. At the root of this directory, run `copilot app delete franklin`.
+1. Answer `Y` if it asks you to confirm the deletion.
+1. After the command is finished, delete the `./copilot` directory.
 
 ## If you make changes to configurations in the addons or the manifest after first deploy
 
@@ -29,12 +29,6 @@ If you make changes:
    - in `copilot/api/manifest.yml`
    - parameters in `copilot/api/addons/**.yml`
    - or add new addons
-
-Run the following command and the CLI should pick up the changes and deploy the infra of the Franklin APIs incrementally.
-
-```
-copilot deploy -a franklin -e production -n api
-```
 
 For example, if you wish to change the running API task from 1 to 0, you may remove the following block from `copilot/api/manifest.yml`:
 
@@ -53,14 +47,24 @@ And then change it to something as below.
 count:0
 ```
 
+Then set the `AWS_PROFILE` environment variable: i.e. `export AWS_PROFILE=franklin`, note that `franklin` is my aws profile name, you should use your own created from the prerequisites section
+
+Run the following command and the CLI should pick up the changes and deploy the infra of the Franklin APIs incrementally.
+
+```
+copilot deploy -a franklin -e production -n api
+```
+
 Find out more information here: https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/#count
 
 
-## Use the deploy script for deployment
+## Use the `./scripts/deploy` script for deployment
 
-1. Make sure to check all the boxes in the prerequisites section, and run `./scripts/deploy`. Then follow the interactive prompts.
+1. Ensure that `AWS_PROFILE` environment variable is set: i.e. `export AWS_PROFILE=franklin`, note that `franklin` is my aws profile name, you should use your own created from the prerequisites section
 
-2. It will first ask you to provide some basic parameters. Please make sure to provide your own parameters. The following are just my examples. E.g.:
+2. Make sure to check all the boxes in the prerequisites section, and run `./scripts/deploy`. Then follow the interactive prompts.
+
+3. It will first ask you to provide some basic parameters. Please make sure to provide your own parameters. The following are just my examples. E.g.:
 
 ```
 What AWS_PROFILE would you like to use...?
@@ -76,13 +80,13 @@ rasterfoundry.com
 Using rasterfoundry.com for your Franklin APIs.
 ```
 
-3. When you are asked if to deploy a test environment, answer `N`. E.g.:
+4. When you are asked if to deploy a test environment, answer `N`. E.g.:
 
 ```
 Would you like to deploy a test environment? [? for help] (y/N) N
 ```
 
-4. When you are asked if to use default environment settings. Choose `Yes, use default`. E.g.:
+5. When you are asked if to use default environment settings. Choose `Yes, use default`. E.g.:
 
 ```
 Would you like to use the default configuration for a new environment?
@@ -97,7 +101,8 @@ Would you like to use the default configuration for a new environment?
 
 
 ## Step-by-step Instructions
-1. `copilot app init franklin --domain <your registered DomainName here>`
+1. Ensure that `AWS_PROFILE` environment variable is set: i.e. `export AWS_PROFILE=franklin`, note that `franklin` is my aws profile name, you should use your own created from the prerequisites section
+2. `copilot app init franklin --domain <your registered DomainName here>`
     
     - It is required that you have a registered domain name in Amazon Route53 before this step.
     - After going through this tutorial, your load balanced franklin API service is going to be accessible publicly through `${Service}.${Environment}.${Application}.${Domain}`.
@@ -109,7 +114,7 @@ Would you like to use the default configuration for a new environment?
         ✔ The directory copilot will hold service manifests for application franklin.
         ```
 
-2. `copilot init`
+3. `copilot init`
 
     - Run the following command, it will:
       - initialize the infra to manage the containerized services for the `franklin` application's `api` service as a `Load Balanced Web Service`. Note that `--port 9090` is needed.
@@ -131,7 +136,7 @@ Would you like to use the default configuration for a new environment?
         ```
     
     
-3. Override the default template
+4. Override the default template
 
     - In this step, we will override the auto generated `manifest.yml` template so that we will configure the infra further. Run the following commands.
         ```
@@ -163,7 +168,7 @@ Would you like to use the default configuration for a new environment?
             response_time: 2s
         ```
 
-4. Attach a provisioned RDS Postgres 12.7 instance and give ECS task access to S3
+5. Attach a provisioned RDS Postgres 12.7 instance and give ECS task access to S3
 
     - The provisioned RDS instance we will use is of Postgres engine 12.7, which supports the PostGIS version 3.X since the tile rendering endpoints needs methods from this version of PostGI.S
     - Additionally, the ECS task role needs some additional policies attached so that it has S3 access.
@@ -174,7 +179,7 @@ Would you like to use the default configuration for a new environment?
     cp iam.yml ./copilot/api/addons/iam.yml
     ```
 
-5. `copilot env init -n production -a franklin`
+6. `copilot env init -n production -a franklin`
 
     - This command will create a new environment `production` where the serivces will live.
     - After answering the questions as below, it will:
@@ -209,7 +214,7 @@ Would you like to use the default configuration for a new environment?
       ✔ Created environment production in region us-east-1 under application franklin.
     ```
 
-6. Add CDN in front of tile endpoint requests
+7. Add CDN in front of tile endpoint requests
 
     6.1 Get the `CertificateArn` from the subdomain
 
@@ -247,7 +252,7 @@ Would you like to use the default configuration for a new environment?
         Default: <the S3 bucket URL for the CDN logs, e.g. rasterfoundry-production-logs-us-east-1.s3.amazonaws.com>
     ```
 
-7. `copilot deploy -a franklin -e production -n api`
+8. `copilot deploy -a franklin -e production -n api`
 
     - This command will package the `manifest.yml` file and addons into `CloudFormation`, and create and/or update the ECS task definition and attached service.
     - Under the hood, this will create a stack that manages the franklin production API service, and the nested stack attached to the API service for DB and IAM role policy for the ECS task.
@@ -279,7 +284,7 @@ Would you like to use the default configuration for a new environment?
        You can access your service at https://api.production.franklin.rasterfoundry.com over the internet.
     ```
 
-8.  Some commands to check the service
+9.  Some commands to check the service
     - `copilot svc show -a franklin -n api`: This command shows info about the deployed services, including the endpoints, capacity and related resources per environment.
     - `copilot svc status -a franklin -n api -e production`: This command shows the health statuses, e.g. service status, task status, and related CloudWatch alarms etc.
     - `copilot svc logs -a franklin -n api -e production`: This command shows the the logs of the deployed service.

--- a/deployment/aws-copilot/cdn.yml
+++ b/deployment/aws-copilot/cdn.yml
@@ -11,9 +11,11 @@ Parameters:
   CertArn:
     Type: String
     Description: The arn of the certificate created for your DNS
+    Default: CertArnDefault
   LoggingBucket:
     Type: String
     Description: The bucket for the CDN logs
+    Default: LoggingBucketDefault
 
 Resources:
   franklinCDNDistribution:

--- a/deployment/aws-copilot/manifest.yml
+++ b/deployment/aws-copilot/manifest.yml
@@ -17,4 +17,4 @@ count:
   requests: 10000
   response_time: 2s
 exec: true
-command: ["serve", "--with-transactions", "--with-tiles", "--run-migrations", "--external-port", "443", "--api-scheme", "https", "--api-host", "api.production.franklin.rasterfoundry.com"]
+command: ["serve", "--with-transactions", "--with-tiles", "--run-migrations", "--external-port", "443", "--api-scheme", "https", "--api-host", "api.production.franklin.domainname.com"]

--- a/deployment/aws-copilot/scripts/deploy
+++ b/deployment/aws-copilot/scripts/deploy
@@ -1,45 +1,45 @@
 #!/bin/bash
 echo -e "What AWS_PROFILE would you like to use...?" 
 read AWS_PROFILE
-echo "Using $AWS_PROFILE IAM profile to deploy your Franklin instance.\n"
+printf "Using $AWS_PROFILE IAM profile to deploy your Franklin instance.\n\n"
 export AWS_PROFILE=$AWS_PROFILE
 
 echo -e "Please provide S3 URL to the bucket for tile endpoint CDN logging: e.g. example-logs.s3.amazonaws.com..."
 read CDN_LOG_BUCKET
-echo "Using $CDN_LOG_BUCKET for tile endpoint CDN logging.\n"
+printf "Using $CDN_LOG_BUCKET for tile endpoint CDN logging.\n\n"
 
-echo -e "Please provide a domain registered in Route 53: e.g. rasterfoundry.com..."
+echo -e "Please provide a domain registered in Route 53..."
 read DOMAIN_NAME
-echo "Using $DOMAIN_NAME for your Franklin APIs.\n"
+printf "Using $DOMAIN_NAME for your Franklin APIs.\n\n"
 
-echo "Initializing Franklin app...\n"
+printf "Initializing Franklin app...\n\n"
 copilot app init franklin --domain $DOMAIN_NAME
 
-echo "Initializing API service...\n"
+printf "Initializing API service...\n\n"
 echo $(copilot init -a franklin --dockerfile ./Dockerfile --name api --port 9090 -t "Load Balanced Web Service")
 
-echo "Overriding default manifest.yml...\n"
+printf "Overriding default manifest.yml...\n\n"
 rm ./copilot/api/manifest.yml
 cp manifest.yml ./copilot/api/manifest.yml
 
 sed -i "" -e "s~domainname.com~$DOMAIN_NAME~g" ./copilot/api/manifest.yml
 
-echo "Attaching addons...\n"
+printf "Attaching addons...\n\n"
 mkdir ./copilot/api/addons
 cp db.yml ./copilot/api/addons/db.yml
 cp iam.yml ./copilot/api/addons/iam.yml
 
-echo "Initializing production env...\n"
+printf "Initializing production env...\n\n"
 echo $(copilot env init -n production -a franklin --profile $AWS_PROFILE)
 
-echo "Getting certificate ARN...\n"
+printf "Getting certificate ARN...\n\n"
 aws acm list-certificates
 CertificateArn=$(aws acm list-certificates | jq -rc '.CertificateSummaryList | map(select( .DomainName | contains("production.franklin"))) | .[0].CertificateArn')
 
-echo "Attaching CDN...\n"
+printf "Attaching CDN...\n\n"
 cp cdn.yml ./copilot/api/addons/cdn.yml
 sed -i "" -e "s~CertArnDefault~$CertificateArn~g" ./copilot/api/addons/cdn.yml
 sed -i "" -e "s~LoggingBucketDefault~$CDN_LOG_BUCKET~g" ./copilot/api/addons/cdn.yml
 
-echo "Deploying Franklin API service with CDN...\n"
+printf "Deploying Franklin API service with CDN...\n\n"
 copilot deploy -a franklin -e production -n api

--- a/deployment/aws-copilot/scripts/deploy
+++ b/deployment/aws-copilot/scripts/deploy
@@ -1,0 +1,45 @@
+#!/bin/bash
+echo -e "What AWS_PROFILE would you like to use...?" 
+read AWS_PROFILE
+echo "Using $AWS_PROFILE IAM profile to deploy your Franklin instance.\n"
+export AWS_PROFILE=$AWS_PROFILE
+
+echo -e "Please provide S3 URL to the bucket for tile endpoint CDN logging: e.g. example-logs.s3.amazonaws.com..."
+read CDN_LOG_BUCKET
+echo "Using $CDN_LOG_BUCKET for tile endpoint CDN logging.\n"
+
+echo -e "Please provide a domain registered in Route 53: e.g. rasterfoundry.com..."
+read DOMAIN_NAME
+echo "Using $DOMAIN_NAME for your Franklin APIs.\n"
+
+echo "Initializing Franklin app...\n"
+copilot app init franklin --domain $DOMAIN_NAME
+
+echo "Initializing API service...\n"
+echo $(copilot init -a franklin --dockerfile ./Dockerfile --name api --port 9090 -t "Load Balanced Web Service")
+
+echo "Overriding default manifest.yml...\n"
+rm ./copilot/api/manifest.yml
+cp manifest.yml ./copilot/api/manifest.yml
+
+sed -i "" -e "s~domainname.com~$DOMAIN_NAME~g" ./copilot/api/manifest.yml
+
+echo "Attaching addons...\n"
+mkdir ./copilot/api/addons
+cp db.yml ./copilot/api/addons/db.yml
+cp iam.yml ./copilot/api/addons/iam.yml
+
+echo "Initializing production env...\n"
+echo $(copilot env init -n production -a franklin --profile $AWS_PROFILE)
+
+echo "Getting certificate ARN...\n"
+aws acm list-certificates
+CertificateArn=$(aws acm list-certificates | jq -rc '.CertificateSummaryList | map(select( .DomainName | contains("production.franklin"))) | .[0].CertificateArn')
+
+echo "Attaching CDN...\n"
+cp cdn.yml ./copilot/api/addons/cdn.yml
+sed -i "" -e "s~CertArnDefault~$CertificateArn~g" ./copilot/api/addons/cdn.yml
+sed -i "" -e "s~LoggingBucketDefault~$CDN_LOG_BUCKET~g" ./copilot/api/addons/cdn.yml
+
+echo "Deploying Franklin API service with CDN...\n"
+copilot deploy -a franklin -e production -n api

--- a/deployment/aws-copilot/scripts/deploy
+++ b/deployment/aws-copilot/scripts/deploy
@@ -33,7 +33,6 @@ printf "Initializing production env...\n\n"
 echo $(copilot env init -n production -a franklin --profile $AWS_PROFILE)
 
 printf "Getting certificate ARN...\n\n"
-aws acm list-certificates
 CertificateArn=$(aws acm list-certificates | jq -rc '.CertificateSummaryList | map(select( .DomainName | contains("production.franklin"))) | .[0].CertificateArn')
 
 printf "Attaching CDN...\n\n"


### PR DESCRIPTION
## Overview

This PR:
- adds a `./scripts/deploy` to `./deployment/aws-copilot` directory that automates the step by step deployment instructions
- updates the deployment readme to reflect this above change, and added some examples of how one would make incremental infra changes (e.g. change running task from 1 to 0) and how to take down the deployed app

### Checklist

- ~New tests have been added or existing tests have been modified~

### Testing Instructions

- Ask me for credentials of an AWS test account profile with certain policies attached
- Go over the updated sections in the readme and make sure they make sense to you
- Follow the section `Use the deploy script for deployment` to deploy Franklin API in a more automated way
- Follow the section `If you make changes to configurations in the addons or the manifest after first deploy` and make sure the suggested example works, and that the API returns 503 after the changes from the example
- Follow the section `Before you start` after the above tests to take down the deployed Franklin API

Closes https://github.com/azavea/raster-foundry-platform/issues/1389
